### PR TITLE
retrieval of data after publishing a message made optional

### DIFF
--- a/src/dtps/ergo_create.py
+++ b/src/dtps/ergo_create.py
@@ -323,7 +323,7 @@ class ContextManagerCreateContext(DTPSContext):
         resolve = server._resolve_tn(topic, url0=url0)
         res = await resolve.call(url0, server, data)
         # queue = server.get_oq(topic)
-        # res = await queue.publish(data)
+        # res = await queue.publish(data, get_data=True)
         if isinstance(res, TransformError):
             raise Exception(f"{res.http_code}: {res.message}")
         return res

--- a/src/dtps_http/object_queue.py
+++ b/src/dtps_http/object_queue.py
@@ -128,7 +128,7 @@ class ObjectQueue:
         # self._data = {}
         self._name = name
         self.tr = tr
-        self.stored = deque()
+        self.stored = deque(maxlen=bounds.max_size)
         self.saved = {}
         self._transform = transform
         self.serve = serve
@@ -206,22 +206,22 @@ class ObjectQueue:
         )
 
         # self._data[digest] = obj
-        self.stored.append(use_seq)
-        self.saved[use_seq] = ds
 
         # logger.info(
         #    f'pushing, bounds = {self.bounds}  stored = {len(self.stored)}  saved = {len(self.saved)} '
         #    f'blobs={len(self.blob_manager.blobs)}')
-        if self.bounds.max_size is not None:  # TODO: implement the semantics for others
-            while len(self.stored) > self.bounds.max_size:
-                x_old: int = self.stored.popleft()
-                if x_old in self.saved:  # should always be true
-                    ds_old = self.saved.pop(x_old)
-                    # if TOLERANCE_REMOVAL is not None and TOLERANCE_REMOVAL > 0:
-                    #     # extend deadline by an arbitrary 10 seconds
-                    #     # (should not be needed, but just in case)
-                    #     self.blob_manager.extend_deadline(ds_old.digest, TOLERANCE_REMOVAL)
-                    self.blob_manager.release_blob(ds_old.digest, (self.name_for_blob_manager, x_old))
+        if self.bounds.max_size is not None and len(self.stored) == self.bounds.max_size:  # TODO: implement the semantics for others
+            x_old: int = self.stored[0]
+            if x_old in self.saved:  # should always be true
+                ds_old = self.saved.pop(x_old)
+                # if TOLERANCE_REMOVAL is not None and TOLERANCE_REMOVAL > 0:
+                #     # extend deadline by an arbitrary 10 seconds
+                #     # (should not be needed, but just in case)
+                #     self.blob_manager.extend_deadline(ds_old.digest, TOLERANCE_REMOVAL)
+                self.blob_manager.release_blob(ds_old.digest, (self.name_for_blob_manager, x_old))
+
+        self.stored.append(use_seq)
+        self.saved[use_seq] = ds
 
         inot = InsertNotification(ds, obj0)
         self._pub.publish(

--- a/src/dtps_http/object_queue.py
+++ b/src/dtps_http/object_queue.py
@@ -69,7 +69,7 @@ class SuccessPostResult:
     redirect_url: str
 
 
-PostResult = Union[DataReady, TransformError]
+PostResult = Union[DataReady, TransformError, None]
 GetResult = Union[DataReady, HTTPResponse]
 
 # PublishResult = Union[DataSaved, TransformError]
@@ -156,24 +156,24 @@ class ObjectQueue:
 
     async def publish_text(self, text: str, content_type: ContentType = MIME_TEXT) -> PostResult:
         data = text.encode("utf-8")
-        return await self.publish(RawData(content=data, content_type=content_type))
+        return await self.publish(RawData(content=data, content_type=content_type), get_data=True)
 
     async def publish_cbor(self, obj: object, content_type: ContentType = MIME_CBOR) -> PostResult:
         """Publish a python object as a cbor2 encoded object."""
         data = cbor2.dumps(obj)
-        return await self.publish(RawData(content=data, content_type=content_type))
+        return await self.publish(RawData(content=data, content_type=content_type), get_data=True)
 
     async def publish_json(self, obj: object, content_type: ContentType = MIME_JSON) -> PostResult:
         """Publish a python object as a JSON encoded object."""
         data = json.dumps(obj)  # OK
-        return await self.publish(RawData(content=data.encode(), content_type=content_type))
+        return await self.publish(RawData(content=data.encode(), content_type=content_type), get_data=True)
 
     async def publish_yaml(self, obj: object, content_type: ContentType = MIME_YAML) -> PostResult:
         """Publish a python object as a JSON encoded object."""
         data = yaml.dump(obj)
-        return await self.publish(RawData(content=data.encode(), content_type=content_type))
+        return await self.publish(RawData(content=data.encode(), content_type=content_type), get_data=True)
 
-    async def publish(self, obj0: RawData, /) -> PostResult:
+    async def publish(self, obj0: RawData, /, *, get_data: bool = False) -> PostResult:
         """
         Publish raw bytes.
 
@@ -229,8 +229,9 @@ class ObjectQueue:
         )  # logger.debug(f"published #{self._seq} {self._name}: {obj!r}")
 
         # reached_at = self._name.as_relative_url()
-        data_ready = self.get_data_ready(ds, False, obj.content)
-        return data_ready
+        if get_data:
+            return self.get_data_ready(ds, False, obj.content)
+        return None
 
     def current_clocks(self) -> Clocks:
         clocks = Clocks.empty()

--- a/src/dtps_http/object_queue.py
+++ b/src/dtps_http/object_queue.py
@@ -103,9 +103,9 @@ class ObjectQueue:
     _hub: Hub
     _pub: Publisher
     _sub: Subscriber
+    _transform: ObjectTransformFunction
     tr: TopicRef
     bounds: Bounds
-    transform: ObjectTransformFunction
     blob_manager: BlobManager
     serve: Optional[ObjectServeFunction]
     listeners: "Dict[SUB_ID,  ListenerData]"
@@ -169,7 +169,7 @@ class ObjectQueue:
         return await self.publish(RawData(content=data.encode(), content_type=content_type), get_data=True)
 
     async def publish_yaml(self, obj: object, content_type: ContentType = MIME_YAML) -> PostResult:
-        """Publish a python object as a JSON encoded object."""
+        """Publish a python object as a YAML encoded object."""
         data = yaml.dump(obj)
         return await self.publish(RawData(content=data.encode(), content_type=content_type), get_data=True)
 

--- a/src/dtps_http/types_of_source.py
+++ b/src/dtps_http/types_of_source.py
@@ -238,7 +238,7 @@ class OurQueue(Source):
     async def publish(self, presented_as: str, server: "DTPSServer", rd: RawData) -> "PostResult":
         oq = server.get_oq(self.topic_name)
 
-        otr = await oq.publish(rd)
+        otr = await oq.publish(rd, get_data=True)
         return otr
 
     async def call(
@@ -246,7 +246,7 @@ class OurQueue(Source):
     ) -> Union[RawData, TransformError]:
         oq = server.get_oq(self.topic_name)
 
-        otr = await oq.publish(rd)
+        otr = await oq.publish(rd, get_data=True)
         if isinstance(otr, TransformError):
             return otr
         else:
@@ -277,7 +277,7 @@ class OurQueue(Source):
             raise web.HTTPBadRequest(reason=msg)
         ob2 = cast(Dict[str, Any], ob2)
         rd = RawData.json_from_native_object(ob2)
-        otr = await oq.publish(rd)
+        otr = await oq.publish(rd, get_data=True)
         return otr
 
     async def delete(self, presented_as: str, server: "DTPSServer") -> "Optional[TransformError]":


### PR DESCRIPTION
This pull request refactors several modules to improve consistency in dataclass usage and updates the object queue publishing logic to better handle data retrieval and memory management. The most important changes include replacing `pydantic.dataclasses.dataclass` with the standard library's `dataclasses.dataclass`, modifying the `ObjectQueue`'s `publish` method to support optional data retrieval, and optimizing how published data is stored and evicted. Additionally, related methods and usages throughout the codebase have been updated to reflect these changes.

### Refactoring and Standardization

* Replaced imports of `pydantic.dataclasses.dataclass` with the standard library's `dataclasses.dataclass` across multiple files (`src/dtps_http/link_headers.py`, `src/dtps_http/object_queue.py`, `src/dtps_http/server.py`, `src/dtps_http/structures.py`). [[1]](diffhunk://#diff-22e7624fbf55ddddc6e6e4747213b8ba12d88991f81ff0e5222e5abac0c8fd10L5-R5) [[2]](diffhunk://#diff-b4dddbca3473748a89531bb880f6af27226c4fa12a3487f0522af7e50a885390L4-R15) [[3]](diffhunk://#diff-37fc0a8aa15359ef5056f937f0f54fb0bc7a14cca8bc47930869ebf6cf747e52L43-R43) [[4]](diffhunk://#diff-a7d4f29462e67e3e7da0b6b897e06f24b10b9264c5a254458e431edb38538561L9-R9)

### Object Queue Publishing Logic

* Updated the `ObjectQueue.publish` method to accept a new `get_data` parameter, which determines whether to return the published data or just acknowledge the publish action. The default behavior now returns `None` unless `get_data=True` is specified. [[1]](diffhunk://#diff-b4dddbca3473748a89531bb880f6af27226c4fa12a3487f0522af7e50a885390L159-R192) [[2]](diffhunk://#diff-b4dddbca3473748a89531bb880f6af27226c4fa12a3487f0522af7e50a885390R239-R250)
* Modified related publish methods (`publish_text`, `publish_cbor`, `publish_json`, `publish_yaml`) to pass `get_data=True` to ensure they return the published data as expected.

### Data Storage and Eviction

* Changed the `stored` deque in `ObjectQueue` to use a bounded length (`maxlen=bounds.max_size`) and updated the eviction logic to only remove the oldest item when the maximum size is reached, improving memory management and consistency. [[1]](diffhunk://#diff-b4dddbca3473748a89531bb880f6af27226c4fa12a3487f0522af7e50a885390L131-R147) [[2]](diffhunk://#diff-b4dddbca3473748a89531bb880f6af27226c4fa12a3487f0522af7e50a885390L209-R230)

### Type and Structure Adjustments

* Updated the `PostResult` type to allow `None`, reflecting the new optional return value from the `publish` method.
* Adjusted the internal structure of `ObjectQueue` to rename and clarify member variables, such as using `_transform` instead of `transform`.

### API Usage Updates

* Updated all usages of `ObjectQueue.publish` in `src/dtps_http/types_of_source.py` and `src/dtps/ergo_create.py` to pass `get_data=True`, ensuring correct data retrieval after publishing. [[1]](diffhunk://#diff-da7120701c5691fd70761dc718364b6cabdd5df76c9215cc02311b1656556d1aL241-R249) [[2]](diffhunk://#diff-da7120701c5691fd70761dc718364b6cabdd5df76c9215cc02311b1656556d1aL280-R280) [[3]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceL326-R326)