### PR TITLE
DTSW-7313-Fix-lib-dtps-http-circleci-testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         command: cargo build
     - run: python3 -m pip install nose2
     - run: python3 -m pip install .
-    - run: rm -rf src/dtps_http && find .
+    - run: find .
     - run: python3 -m nose2 src
   "python39":
     <<: *template
@@ -57,7 +57,7 @@ jobs:
     - run: apt-get update && apt-get install -y python3-pip python3-venv
     - run: python3 -m venv .
     - run: ./bin/pip install  .
-    - run: rm -rf src/dtps_http && find .
+    - run: find .
     - run:
         name: Run Tests
         command: "PATH=$PATH:./bin cargo test test_python1"

--- a/rust/src/test_range.rs
+++ b/rust/src/test_range.rs
@@ -492,7 +492,7 @@ pub mod tests {
         post_cbor(&con_topic, &h).await?;
 
         let replace = ReplaceOperation {
-            path: "/value".to_string(),
+            path: jsonptr::PointerBuf::try_from("/value").unwrap(),
             value: serde_json::Value::String("new".to_string()),
         };
         let operation = PatchOperation::Replace(replace);
@@ -502,7 +502,7 @@ pub mod tests {
         // now test something that should fail
         info!("Testing NOTEXISTING addressing");
         let replace = ReplaceOperation {
-            path: "/NOTEXISTING".to_string(),
+            path: jsonptr::PointerBuf::try_from("/NOTEXISTING").unwrap(),
             value: serde_json::Value::String("new".to_string()),
         };
         let operation = PatchOperation::Replace(replace);
@@ -513,7 +513,7 @@ pub mod tests {
         let value2 = json!({"A": {"B": ["C", "D"]}});
         info!("----\nTesting replacing entire value ({h:?}) with a new one ({value2:?})");
         let replace = ReplaceOperation {
-            path: "".to_string(),
+            path: jsonptr::PointerBuf::try_from("").unwrap(),
             value: value2,
         };
         let operation = PatchOperation::Replace(replace);
@@ -526,11 +526,11 @@ pub mod tests {
         info!("----\nTesting adding first and last to array");
         let b_address = con_topic.join("A/B/")?;
         let add_operation1 = AddOperation {
-            path: "/0".to_string(),
+            path: jsonptr::PointerBuf::try_from("/0").unwrap(),
             value: json!("start"),
         };
         let add_operation2 = AddOperation {
-            path: "/-".to_string(),
+            path: jsonptr::PointerBuf::try_from("/-").unwrap(),
             value: json!("end"),
         };
         let operation1 = PatchOperation::Add(add_operation1);
@@ -868,7 +868,7 @@ pub mod tests {
         info!("proxied_topic: {}", proxied_topic.to_url_repr());
 
         let patch = Patch(vec![PatchOperation::Add(AddOperation {
-            path: "/added".to_string(),
+            path: jsonptr::PointerBuf::try_from("/added").unwrap(),
             value: serde_json::Value::String("new".to_string()),
         })]);
 


### PR DESCRIPTION
This pull request primarily refactors how JSON pointer paths are handled in Rust test cases and makes a minor cleanup in the CI configuration. The main improvement is the transition from using plain strings to strongly-typed `jsonptr::PointerBuf` for JSON pointer paths, enhancing type safety and reducing potential errors in path handling.

**Rust test improvements:**

* Updated all test cases in `rust/src/test_range.rs` to use `jsonptr::PointerBuf::try_from(...)` instead of plain strings for JSON pointer paths in `ReplaceOperation` and `AddOperation`, improving type safety and clarity. [[1]](diffhunk://#diff-c9646f775e7ebc50d5977cb84511b186243320f3743710dd9346a55177c5c6c7L495-R495) [[2]](diffhunk://#diff-c9646f775e7ebc50d5977cb84511b186243320f3743710dd9346a55177c5c6c7L505-R505) [[3]](diffhunk://#diff-c9646f775e7ebc50d5977cb84511b186243320f3743710dd9346a55177c5c6c7L516-R516) [[4]](diffhunk://#diff-c9646f775e7ebc50d5977cb84511b186243320f3743710dd9346a55177c5c6c7L529-R533) [[5]](diffhunk://#diff-c9646f775e7ebc50d5977cb84511b186243320f3743710dd9346a55177c5c6c7L871-R871)

**CI/CD configuration cleanup:**

* Removed unnecessary `rm -rf src/dtps_http` commands from the `.circleci/config.yml` jobs to simplify and clarify the build process. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L22-R22) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L60-R60)