### PR TITLE
DTSW-7445-Fix-dt-ros-interface-high-CPU-usage-bug

### DIFF
--- a/src/dtps_http/utils.py
+++ b/src/dtps_http/utils.py
@@ -31,7 +31,7 @@ from typing import (
 
 import cbor2
 from multidict import CIMultiDict, CIMultiDictProxy
-from pydantic import parse_obj_as
+from pydantic import TypeAdapter
 from typing_extensions import ParamSpec
 
 from . import logger
@@ -217,6 +217,12 @@ def parse_tagged(d: Dict[str, Any], *Ts: Type[X]) -> X:
     raise ValueError(f"parse_tagged: {d!r} does not have any of {Ts!r}")
 
 
+@functools.lru_cache(maxsize=128)
+def _get_type_adapter(T: Type[X]) -> TypeAdapter[X]:
+    """Cache TypeAdapter instances to avoid repeated schema generation."""
+    return TypeAdapter(T)
+
+
 def pydantic_parse(T: Type[X], d: Any) -> X:
     """
     Parses data into either a Pydantic model or a standard dataclass.
@@ -228,9 +234,10 @@ def pydantic_parse(T: Type[X], d: Any) -> X:
     Returns:
         An instance of T.
     """
-    # Try Pydantic parse
+    # Use cached TypeAdapter
     try:
-        return parse_obj_as(T, d)
+        adapter = _get_type_adapter(T)
+        return adapter.validate_python(d)
     except Exception:
         # Fallback for standard dataclasses
         if dataclasses.is_dataclass(T):


### PR DESCRIPTION
This pull request improves the way Pydantic types are parsed in the `src/dtps_http/utils.py` module by switching from the deprecated `parse_obj_as` to the more efficient and modern `TypeAdapter` API. Additionally, it introduces caching for type adapters to optimize performance and avoid repeated schema generation.

**Pydantic parsing improvements:**

* Replaced the use of `parse_obj_as` with `TypeAdapter` in the `pydantic_parse` function, aligning with current Pydantic best practices and improving compatibility with Pydantic v2. (`src/dtps_http/utils.py`) [[1]](diffhunk://#diff-8fa006d36898c9d9fbbcef257fa3040e43a8cddca02657c81f087e281251736fL34-R34) [[2]](diffhunk://#diff-8fa006d36898c9d9fbbcef257fa3040e43a8cddca02657c81f087e281251736fL231-R240)
* Introduced a cached `_get_type_adapter` function using `functools.lru_cache` to store `TypeAdapter` instances, reducing overhead from repeated schema generation. (`src/dtps_http/utils.py`)