### PR TITLE
DTSW-7931-Remove-poetry-dynamic-versioning-in-lib-dtps-http

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 
 [tool]
@@ -49,20 +49,3 @@ dtps-http-py-proxy = 'dtps_http_programs:dtps_proxy_main'
 dtps-http-py-send-continuous = 'dtps_http_programs:dtps_send_continuous_main'
 dtps-http-py-listen= 'dtps_http_programs:dtps_listen_main'
 dtps-http-py= 'dtps_http_programs:dtps_main'
-
-
-[tool.poetry-dynamic-versioning]
-enable = true
-dirty = false
-metadata = false
-tagged-metadata = false
-vcs = "git"
-style = "pep440"
-strict = false
-
-
-
-[tool.poetry-dynamic-versioning.substitution]
-folders = [
-    { path = "src" }
-]


### PR DESCRIPTION
This pull request updates the project's build configuration by removing the use of `poetry-dynamic-versioning` and switching to the default Poetry backend. The changes simplify version management and the build process.

**Build system changes:**

* Updated the `[build-system]` section in `pyproject.toml` to remove `poetry-dynamic-versioning` from the `requires` list and set the `build-backend` to Poetry's default backend (`poetry.core.masonry.api`).

**Configuration cleanup:**

* Removed all `[tool.poetry-dynamic-versioning]` and `[tool.poetry-dynamic-versioning.substitution]` configuration blocks from `pyproject.toml`, eliminating custom dynamic versioning settings.