### PR TITLE
DTSW-7841-Address-security-issues-in-lib-dtps-http

### DIFF
--- a/src/dtps_http/server.py
+++ b/src/dtps_http/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import html
 import pathlib
 import time
 import traceback
@@ -1283,6 +1284,7 @@ class DTPSServer:
                 return web.Response(body=rd.content, content_type=rd.content_type, headers=headers)
         elif isinstance(rd, NotAvailableYet):  # type: ignore
             if accepts_html:
+                safe_title = html.escape(title, quote=True)
                 # language=html
                 html_index = f"""
 <html lang="en">
@@ -1295,10 +1297,10 @@ pre {{
     border-radius: 5px; 
 }}
 </style>
-<title>{title}</title>
+<title>{safe_title}</title>
 </head>
 <body>
-<h1>{title}</h1>
+<h1>{safe_title}</h1>
 
 <p>There is no data yet to visualize.</p>
 


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/lib-dtps-http/security/code-scanning/8](https://github.com/duckietown/lib-dtps-http/security/code-scanning/8)

To fix reflected XSS, escape all untrusted data before embedding it into HTML. Here, the best minimal fix is to HTML-escape `title` at the point where HTML is generated in `visualize_data`, so all call paths (`serve_history`, `serve_meta`, `serve_get`) are covered by one change and behavior remains otherwise unchanged.

In `src/dtps_http/server.py`:
1. Add `import html` alongside existing imports.
2. In `visualize_data(...)`, in the `accepts_html` branch for `NotAvailableYet`, create an escaped variable (for example, `safe_title = html.escape(title, quote=True)`).
3. Use `safe_title` in `<title>` and `<h1>` instead of raw `title`.

This is the single best fix in the shown code because it addresses all reported variants at the common sink while preserving existing response structure and logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
