### PR TITLE
DTSW-7841-Address-security-issues-in-lib-dtps-http

### DIFF
--- a/src/dtps_http/server.py
+++ b/src/dtps_http/server.py
@@ -1384,7 +1384,7 @@ pre {{
             return self.resolve(topic_name_s)
         except KeyError as e:
             # self.logger.error(f"serve_get: {request.url!r} -> {topic_name_s!r} -> {e}")
-            raise web.HTTPNotFound(text=f"404\n{e}", headers=self._headers(request)) from e
+            raise web.HTTPNotFound(text="404", headers=self._headers(request)) from e
 
     @async_error_catcher
     async def serve_post(self, request: web.Request) -> web.Response:


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/lib-dtps-http/security/code-scanning/5](https://github.com/duckietown/lib-dtps-http/security/code-scanning/5)

The best fix is to return a **generic 404 message** to clients and avoid interpolating the exception object into response text.  
In `src/dtps_http/server.py`, in `_resolve()` around lines 1383–1387:

- Keep catching `KeyError` so behavior (404 status) is unchanged.
- Replace `text=f"404\n{e}"` with a constant generic string such as `"404"`.
- Keep `from e` to preserve exception chaining for server-side diagnostics without exposing details in HTTP output.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
