### PR TITLE
DTSW-7841-Address-security-issues-in-lib-dtps-http

### DIFF
--- a/src/dtps_http/server.py
+++ b/src/dtps_http/server.py
@@ -1192,11 +1192,15 @@ class DTPSServer:
     ) -> web.StreamResponse:
         headers: CIMultiDict[str] = CIMultiDict()
 
+        escaped_title = html.escape(title)
+        escaped_content_type = html.escape(content_type)
+        escaped_initial_data_html = html.escape(initial_data_html)
+
         # language=html
         html_index = f"""\
 <html lang="en">
 <head>
-    <title>{title}</title>
+    <title>{escaped_title}</title>
     <link rel="stylesheet" href="/static/style.css">
     <script src="/static/send.js"></script>
 
@@ -1205,23 +1209,23 @@ class DTPSServer:
 
 </head>
 <body>
-<h1>{title}</h1>
+<h1>{escaped_title}</h1>
 
 <p>This response coming to you in HTML format because you requested it in HTML format.</p>
 
-<p>Content type: <code>{content_type}</code></p>
+<p>Content type: <code>{escaped_content_type}</code></p>
 
         """
         if is_image_content:
             # language=html
             html_index += f"""
-                <img id="data_field_image" src="data:{content_type};base64,{initial_data_html}" alt="image"/>
+                <img id="data_field_image" src="data:{escaped_content_type};base64,{escaped_initial_data_html}" alt="image"/>
             
             """
         else:
             # language=html
             html_index += f"""
-                <pre id="data_field"><code>{initial_data_html}</code></pre>
+                <pre id="data_field"><code>{escaped_initial_data_html}</code></pre>
             """
         if pushable:
             # language=html


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/lib-dtps-http/security/code-scanning/7](https://github.com/duckietown/lib-dtps-http/security/code-scanning/7)

Use HTML output encoding for every untrusted/dynamic value interpolated into HTML in `make_friendly_visualization()`.

Best single fix (without changing behavior): in `src/dtps_http/server.py`, inside `make_friendly_visualization`, create escaped versions of `title`, `content_type`, and `initial_data_html` using the already-imported `html.escape()`, then use those escaped variables in the HTML template. For the image branch, keep base64 data functionality unchanged but still HTML-escape the attribute fragments (`content_type` and base64 string) before interpolation. For the non-image branch, escape displayed text before embedding in `<code>...</code>`. This addresses all variants because they share the same sink and rendering path.

No new imports or dependencies are needed (`html` is already imported at line 3).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
