### PR TITLE
DTSW-7841-Address-security-issues-in-lib-dtps-http

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-jira-key:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/lib-dtps-http/security/code-scanning/1](https://github.com/duckietown/lib-dtps-http/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.

Best fix here: define workflow-level permissions directly under `on:` (before `jobs:`), since there is only one job and it needs no write access. Use the minimal read-only scope needed for this type of check:

- `contents: read`

This preserves existing functionality because the script only reads event data from context and does not perform write operations.

File to edit:
- `.github/workflows/jira-pr-check.yml`
  - Insert a top-level `permissions:` block between the trigger (`on:`) and `jobs:`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
