### PR TITLE
DTSW-7841-Address-security-issues-in-lib-dtps-http

### DIFF
--- a/src/dtps_http/server.py
+++ b/src/dtps_http/server.py
@@ -1143,7 +1143,7 @@ class DTPSServer:
                 rs = await source.get_resolved_data(url, self, request)
             except KeyError as e:
                 self.logger.error(f"serve_get: {request.url!r} -> {topic_name_s!r} -> {e}")
-                raise web.HTTPNotFound(text=f"404\n{e}", headers=headers) from e
+                raise web.HTTPNotFound(text="404\nNot Found", headers=headers) from e
 
             if isinstance(rs, HTTPResponse):
                 return rs


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/lib-dtps-http/security/code-scanning/4](https://github.com/duckietown/lib-dtps-http/security/code-scanning/4)

To fix this, stop returning raw exception details to the client and return a generic not-found message instead, while keeping detailed information only in server logs.

Best single change (no functionality break): in `src/dtps_http/server.py` around lines 1144–1146, keep the existing log line, but replace:

- `raise web.HTTPNotFound(text=f"404\n{e}", headers=headers) from e`

with a sanitized message such as:

- `raise web.HTTPNotFound(text="404\nNot Found", headers=headers) from e`

This preserves HTTP status, headers, and error flow while removing exception-derived text exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
