### PR TITLE
DTSW-8151-Update-lib-dtps-http-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,20 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-cbor2 = ">=5.9.0,<6"
-aiohttp = "3.13.3"
+cbor2 = [
+    { version = "5.6.5", python = ">=3.8,<3.9" },
+    { version = ">=5.9.0,<6", python = ">=3.9" },
+]
+aiohttp = [
+    { version = "3.10.11", python = ">=3.8,<3.9" },
+    { version = "3.13.3", python = ">=3.9" },
+]
 tcp_latency = "0.0.12"
 typing_extensions = "^4"
-pymdown-extensions = "^10.21.3"
+pymdown-extensions = [
+    { version = "10.15", python = ">=3.8,<3.9" },
+    { version = "^10.21.3", python = ">=3.9" },
+]
 aiopubsub = "^3"
 methodtools = "^0.4"
 pydantic = "2.10.6"

--- a/src/dtps_http/client.py
+++ b/src/dtps_http/client.py
@@ -611,7 +611,11 @@ class DTPSClient:
 
             timeout = aiohttp.ClientTimeout(total=conn_timeout)
             async with connector:
-                async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+                async with aiohttp.ClientSession(
+                    connector=connector,
+                    timeout=timeout,
+                    auto_decompress=False,
+                ) as session:
                     # self.logger.debug(f"my_session: {url} -> {use_url}")
                     yield session, use_url
 

--- a/src/dtps_http/server_start.py
+++ b/src/dtps_http/server_start.py
@@ -157,7 +157,7 @@ async def app_start(
     no_alternatives: bool = False,
     extra_advertise: Optional[List[URLString]] = None,
 ) -> ServerWrapped:
-    runner = web.AppRunner(s.app)
+    runner = web.AppRunner(s.app, auto_decompress=False)
     await runner.setup()
 
     tunnel_process = None

--- a/src/dtps_http_tests/test_server.py
+++ b/src/dtps_http_tests/test_server.py
@@ -1,12 +1,16 @@
 import asyncio
+import gzip
 import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from typing import cast, List, Literal
 
+import aiohttp
 import cbor2
 import yaml
+from aiohttp import web
 
 from dtps_http import (
     app_start,
@@ -133,6 +137,88 @@ class TestAsyncServerFunction(unittest.IsolatedAsyncioTestCase):
                 pass
             else:
                 raise
+
+    @test_timeout(10)
+    async def test_compressed_request_is_not_decompressed(self) -> None:
+        """Preserve compressed request bodies."""
+        with tempfile.TemporaryDirectory() as td:
+            socket_path = Path(td) / "node"
+            socket_node = str(socket_path)
+            dtps_server = DTPSServer.create(nickname="node")
+            server = await app_start(dtps_server, unix_paths=[socket_node])
+            compressed = gzip.compress(b'{"value": 1}')
+            connector = aiohttp.UnixConnector(path=socket_node)
+            session = aiohttp.ClientSession(connector=connector)
+
+            async with server, session:
+                url0 = make_http_unix_url(socket_node)
+                topic = TopicNameV.from_dash_sep("a/b")
+                parameters = TopicRefAdd(
+                    content_info=ContentInfo.simple(MIME_JSON),
+                    properties=TopicProperties.rw_pushable(),
+                    app_data={},
+                    bounds=Bounds.unbounded(),
+                )
+
+                async with DTPSClient.create() as client:
+                    url_indexer = cast(
+                        "URLIndexer",
+                        url0,
+                    )
+                    await client.add_topic(url_indexer, topic, parameters)
+
+                    async with session.post(
+                        "http://localhost/a/b/",
+                        data=compressed,
+                        headers={
+                            "Content-Encoding": "gzip",
+                            "Content-Type": MIME_JSON,
+                        },
+                    ) as response:
+                        response.raise_for_status()
+
+                async with DTPSClient.create() as client:
+                    topic_path = topic.as_relative_url()
+                    topic_url = join(url0, topic_path)
+                    result = await client.get(topic_url, accept=None)
+
+                if result.content != compressed:
+                    raise AssertionError
+
+    @test_timeout(10)
+    async def test_client_does_not_decompress_response(self) -> None:
+        """Preserve compressed response bodies."""
+        compressed = gzip.compress(b"compressed response")
+
+        async def serve_compressed(_: web.Request) -> web.Response:
+            return web.Response(
+                body=compressed,
+                headers={
+                    "Content-Encoding": "gzip",
+                    "Content-Type": "application/octet-stream",
+                },
+            )
+
+        app = web.Application()
+        app.router.add_get("/", serve_compressed)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        port = 8436
+        site = web.TCPSite(runner, "127.0.0.1", port)
+        await site.start()
+        url = parse_url_unescape(URLString(f"http://127.0.0.1:{port}/"))
+
+        try:
+            client_context = DTPSClient.create()
+            async with client_context as client, client.my_session(url) as (
+                session,
+                use_url,
+            ):
+                async with session.get(use_url) as response:
+                    if await response.read() != compressed:
+                        raise AssertionError
+        finally:
+            await runner.cleanup()
 
     @test_timeout(10)
     async def test_patch1_json_json(self) -> None:


### PR DESCRIPTION
This pull request improves how compressed HTTP request and response bodies are handled in the codebase, ensuring that data is not automatically decompressed by the server or client. It also updates dependency specifications for better compatibility with different Python versions and adds tests to verify the correct handling of compressed data.

**Compressed data handling:**

* Updated `aiohttp.ClientSession` and `web.AppRunner` instantiations to set `auto_decompress=False`, ensuring that compressed HTTP bodies are preserved and not automatically decompressed by the HTTP client or server (`src/dtps_http/client.py`, `src/dtps_http/server_start.py`). [[1]](diffhunk://#diff-b2405e886f731a50a48f0ac02ab62e584bbfdd17f0b3da55c65e79c5ee43803bL614-R618) [[2]](diffhunk://#diff-82e6078cd067d0306fe6c08acb3ee5e7cd9c54adfb7aaf8fb1454d0a3e7053a8L160-R160)

**Dependency management:**

* Modified `pyproject.toml` to specify version constraints for `cbor2`, `aiohttp`, and `pymdown-extensions` based on the Python version, improving compatibility across Python 3.8 and 3.9+ environments.

**Testing improvements:**

* Added two tests in `test_server.py`:
    * `test_compressed_request_is_not_decompressed`: Verifies that compressed request bodies are preserved and not decompressed by the server.
    * [`test_client_does_not_decompress_response`](diffhunk://#diff-25873ca9ece09c9f014e86a8419b3e6b9417cc25f95885fb3cc624dba7953936R141-R222): Verifies that compressed response bodies are preserved and not decompressed by the client.
* Added necessary imports (`gzip`, `aiohttp`, `web`) to support the new tests.