### PR TITLE
DTSW-8150-Implement-shared-memory-option-for-DTPS

### DIFF
--- a/docs/src/_toc.yml
+++ b/docs/src/_toc.yml
@@ -15,6 +15,7 @@ parts:
   numbered: False
   chapters:
   - file: impl/environment
+  - file: impl/shm
 
 
 - caption: Examples low-level API

--- a/docs/src/impl/shm.md
+++ b/docs/src/impl/shm.md
@@ -1,0 +1,405 @@
+# Latest-Value Shared-Memory Transport
+
+[shm.py](../../../src/dtps_http/shm.py) provides a local, one-producer/one-consumer
+transport for the most recent opaque byte payload. It avoids copying a payload
+through a socket or message broker: the bytes live in a memory-mapped file,
+while a FIFO only wakes the reader after a successful update.
+
+This is a latest-value transport, not a reliable queue. It is intended for a
+single `ShmWriter` and a single `ShmReader` on the same host with the required
+POSIX capabilities.
+
+It is not zero-copy end to end. A writer copies its input into the mapped
+buffer and a reader copies a coherent snapshot out of it. The DTPS integration
+also creates a CBOR envelope around each `RawData` value. The benefit is
+removing socket or broker delivery from the local data path, not eliminating
+all application-level copies.
+
+The transport requires POSIX advisory locks, FIFOs, no-follow file opens, and
+positional file I/O. Constructing a writer or reader on a platform that lacks
+one of those capabilities raises `OSError` and names the missing capability;
+there is no insecure fallback.
+
+Both endpoints must be able to access the same writable channel directory.
+For containers, mount that directory into both containers. The immediate
+channel directory must be a real directory owned by the current OS user or
+root, and it must not be writable by other users. Every existing ancestor is
+also checked: it must be owned by the current OS user or root, real rather
+than a symlink, and not writable by other users unless it is sticky. This
+permits a private directory nested below `/tmp` while preventing an attacker
+from replacing path components. Missing directory components are created and
+set to `0700` before the next component is created. Either endpoint can start
+first. New channel data, lock, and FIFO entries use owner-only `0600`
+permissions regardless of the process umask. The default therefore requires
+both endpoints to run as the same OS user. Cross-user deployments are not
+supported because the channel directory and signal FIFO must remain private to
+one account. Do not point a channel path directly into `/tmp` or another
+world-writable directory.
+
+## When to Use It
+
+Use SHM for a local stream where only the newest value matters, such as
+compressed camera images, rendered previews, high-rate state estimates, or
+visualization data. A slow consumer can skip intermediate values and still
+recover the latest complete payload.
+
+Do not use it for commands, transactions, event logs, ordered histories,
+exactly-once delivery, cross-host delivery, or fan-out to multiple independent
+consumers. Use normal DTPS delivery or a queue with the required reliability
+contract for those cases.
+
+## Deployment Checklist
+
+1. Use one base channel path for each directed producer-to-consumer stream.
+  The writer and reader must resolve their `shm_path` to the same file in the
+  shared directory; distinct streams need distinct base paths.
+2. For containers, mount the same private directory into both containers. The
+  data file alone is insufficient because the `.lock` and `.p2c` artifacts
+  are part of the channel.
+3. Run endpoints under compatible OS identities. New artifacts are `0600` and
+  the channel directory is `0700`, so the usual deployment runs both
+  containers as the same UID.
+4. Keep one low-level reader or `subscribe(..., shm_only=True)` consumer per
+  channel. FIFO bytes are consumed by one reader; they are not broadcast to
+  every reader.
+5. Treat the directory as private endpoint state. Do not replace, chmod, or
+  remove channel artifacts while either endpoint is active.
+6. Monitor writer warnings. A failed SHM write can use a publisher's normal
+  transport fallback, but an SHM-only subscriber cannot receive that fallback
+  message.
+
+## Public API
+
+- `ShmWriter(channel_path, logwarn, logerr)` publishes the latest `bytes`
+  payload with `publish(payload)`, clears retained state with `clear()`, and
+  releases local resources with `close()`.
+- `ShmReader(channel_path, on_payload, logwarn, logerr)` starts delivery with
+  `start(deliver_current=True)` and releases local resources with `stop()`.
+
+## DTPS API
+
+`DTPSContext.publish()`, `PublisherInterface.publish()`, and
+`DTPSContext.subscribe()` accept these optional keyword arguments:
+
+```python
+shm_path: Optional[str] = None
+shm_only: bool = False
+```
+
+Use them at the DTPS boundary instead of managing `ShmWriter` or `ShmReader`
+in application code:
+
+```python
+await topic.publish(
+  raw_data,
+  shm_path="/data/ramdisk/example",
+  shm_only=True,
+)
+
+subscription = await topic.subscribe(
+  on_data,
+  shm_path="/data/ramdisk/example",
+  shm_only=True,
+)
+```
+
+The transport choice is local to each call. First identify the normal DTPS
+path that the selected API would use without SHM:
+
+| Context and API | Normal publisher or subscriber path |
+| --- | --- |
+| Remote `DTPSContext.publish()` | One HTTP POST per publication. |
+| Remote `PublisherInterface.publish()` returned by `DTPSContext.publisher()` | A persistent WebSocket publisher. |
+| Remote `DTPSContext.subscribe(..., inline=True)` | Inline event data over a WebSocket. |
+| Create-side `DTPSContext.publish()` or `publisher()` | Direct local object-queue publication. |
+| Create-side `DTPSContext.subscribe()` | Direct local object-queue callback. |
+
+`shm_path` and `shm_only` change publisher and subscriber selection
+independently.
+
+### Publisher Selection
+
+| `shm_path` | `shm_only` | Behavior |
+| --- | --- | --- |
+| Empty | `False` | Uses the normal path above. |
+| Set | `False` | Attempts an SHM mirror, then always uses the normal path. A mirror failure does not prevent normal delivery. |
+| Set | `True` | Attempts SHM first. A successful write suppresses the normal path. An SHM write failure uses the normal path as a fallback. |
+
+The fallback follows the API that made the call: a direct remote
+`DTPSContext.publish()` falls back to HTTP POST, a remote publisher object
+falls back to its persistent WebSocket, and a create-side context falls back
+to its local object queue.
+
+### Subscriber Selection
+
+| `shm_path` | `shm_only` | Behavior |
+| --- | --- | --- |
+| Empty | `False` | Uses the normal path above. |
+| Set | `False` | Still uses only normal DTPS delivery, which prevents duplicate callbacks when a producer mirrors to SHM. |
+| Set | `True` | Starts a local SHM reader and does not wait for normal DTPS availability. |
+
+`shm_only=True` requires a nonempty `shm_path`; otherwise the API raises
+`ValueError`. An SHM-only subscriber does not receive a publisher's normal
+transport fallback after an SHM write failure. If every message must remain
+observable during an SHM outage, leave the consumer on normal DTPS delivery or
+provide an application-level recovery path.
+
+An SHM-only subscription applies `max_frequency` locally before queueing its
+callback. When supplied, it must be a finite positive number; use `None` for
+no local rate limit. The `inline` option has no effect because SHM delivery
+does not use an event endpoint.
+
+### DTPS SHM Envelope
+
+The low-level channel stores opaque bytes. The DTPS adapter serializes each
+`RawData` value as a versioned CBOR mapping containing `version` (currently
+`1`), `content` (the original bytes), and `content_type` (the original media
+type as text). When it reads a channel published through the DTPS API, a
+low-level `ShmReader` receives this envelope rather than the raw application
+payload. Conversely,
+`subscribe(..., shm_only=True)` accepts only this DTPS envelope; invalid
+envelopes are logged and ignored without stopping the subscription.
+
+Context managers reuse writers by channel path and close writers and active
+SHM subscriptions during `aclose()`. The returned SHM subscription owns its
+reader; call `await subscription.unsubscribe()` when the consumer ends rather
+than relying only on manager shutdown.
+
+## Channel Files
+
+Given a channel path such as `/data/ramdisk/dtps/latest-value`, the transport creates three
+files:
+
+| Entry | Path | Purpose |
+| --- | --- | --- |
+| Data | `<channel>` | Mapped bytes. |
+| Lock | `<channel>.lock` | Advisory `flock`. |
+| Signal | `<channel>.p2c` | Wake-up FIFO. |
+
+```mermaid
+flowchart TB
+  Channel["channel"]
+  Channel --> Data["data"]
+  Channel --> Lock[".lock"]
+  Channel --> Signal[".p2c"]
+```
+
+The backing file starts with a 16-byte little-endian header:
+
+| Field | Size |
+| --- | --- |
+| Magic: `DTCM` | 4 B |
+| Version | 4 B |
+| Capacity | 4 B |
+| Payload length | 4 B |
+| Payload | Up to capacity |
+
+`payload length == 0` means that no complete payload is currently available.
+The writer uses this value while it replaces the payload, and again while it
+resizes the backing file.
+
+The `DTCM` marker and version identify the generic payload transport.
+
+The initial capacity is 1 MiB. When necessary, the writer grows the backing
+file to at least the requested size, generally by doubling capacity, up to a
+64 MiB payload ceiling. A larger low-level payload raises `ValueError`.
+Through the DTPS API, that SHM write failure follows the publisher fallback
+rules above.
+
+Artifacts persist after `close()` so a later reader can inspect a retained
+payload. There is no automatic cleanup API. Once every endpoint has stopped,
+an operator may remove the base file, `.lock`, and `.p2c` together to discard
+state. Never remove one artifact alone or delete any artifact while another
+endpoint might still use the channel.
+
+## Publish and Receive Flow
+
+The lock file is separate from the backing file so resizing cannot invalidate
+the inode used for synchronization. The lock is advisory: both endpoints must
+use this implementation for the coherent-copy guarantee to apply.
+
+```mermaid
+sequenceDiagram
+    participant W as Writer
+    participant R as Reader
+
+  W->>W: LOCK_EX, clear length, resize if needed, write payload
+  W->>W: Commit payload length and release lock
+  W-->>R: FIFO wake-up
+  R->>R: Drain queued tokens
+  R->>R: LOCK_SH, remap, and copy
+  R->>R: Invoke callback
+```
+
+The writer grows the buffer when a payload exceeds its current capacity. It
+performs the resize under `LOCK_EX`, resets the payload length to zero, remaps
+its buffer, and then publishes the new payload. A reader observes the updated
+capacity under `LOCK_SH` and remaps before copying.
+
+## Delivery Semantics
+
+- A delivered payload is coherent: the cooperating writer cannot overwrite it
+  while the reader holds its shared lock.
+- The newest payload can overwrite an unread payload. There is no per-frame
+  acknowledgement or delivery guarantee.
+- FIFO tokens are wake-ups, not frame identifiers. The reader coalesces queued
+  tokens and then copies the newest complete payload.
+- A full FIFO does not block the writer. It drops extra wake-ups because an
+  existing queued token will still cause the reader to inspect the latest
+  payload.
+- Consumers must tolerate dropped payloads and occasional repeated delivery.
+- With the default `deliver_current=True`, `start()` delivers a retained
+  payload synchronously before it starts the worker. Later callbacks run in
+  the daemon worker thread, so callbacks must be safe in both contexts.
+- Multiple readers are not supported: they would compete for bytes in the same
+  FIFO rather than each receiving every wake-up.
+
+For a DTPS SHM-only subscription, the reader decodes the envelope and schedules
+the async user callback on the event loop that created the subscription. A
+slow callback fills a positive bounded pending queue; stale pending callbacks
+are discarded in favor of the newest value. Callback exceptions are logged and
+do not stop the reader or callback processor. This is an additional
+latest-value boundary beyond FIFO wake-up coalescing.
+
+The module validates the header and rejects an existing signal path that is not
+a FIFO or is a symlink. It also opens data and lock artifacts without following
+symlinks, requires each to be a singly linked regular file, and verifies that
+after opening its file descriptor. A new or truncated backing file is recreated
+under the exclusive lock. A corrupt or incompatible header is also recreated
+and emits a warning.
+
+## Lifecycle
+
+`ShmWriter.publish(payload)` creates the channel lazily. Empty payloads are
+ignored. `ShmWriter.clear()` removes a retained snapshot but does not wake a
+reader or invoke a callback. Use it before a fresh producer session when a
+later `start(deliver_current=True)` must not receive retained state. Call
+`ShmWriter.close()` when the producer shuts down.
+
+`ShmReader.start()` opens the channel, delivers the current payload when
+one already exists, and starts a daemon worker thread. Use
+`ShmReader.start(deliver_current=False)` when a fresh consumer session must
+ignore the retained payload and drain pending wake-ups before it starts. Call
+`ShmReader.stop()` during shutdown. It waits briefly for the worker; if a
+callback is still running, the worker releases the mapping, FIFO, and lock file
+after that callback returns. A stopped reader can start again after its worker
+has exited.
+
+`ShmWriter.close()` and `ShmReader.stop()` release local descriptors and maps;
+they do not unlink channel artifacts.
+
+## Minimal Usage
+
+```python
+from dtps_http.shm import ShmReader, ShmWriter
+
+
+def log_message(message: str) -> None:
+    print(message)
+
+
+received = []
+
+
+def handle_payload(payload: bytes) -> None:
+    received.append(payload)
+
+
+channel_path = "/data/ramdisk/dtps/latest-value"
+writer = ShmWriter(channel_path, log_message, log_message)
+reader = ShmReader(
+    channel_path,
+    handle_payload,
+    log_message,
+    log_message,
+)
+try:
+    writer.publish(b"latest payload")
+    reader.start()
+
+    assert received == [b"latest payload"]
+finally:
+    reader.stop()
+    writer.close()
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `shm_path is required when shm_only is True` | An SHM-only call omitted its base channel path. | Supply the same nonempty `shm_path` to the intended writer and reader. |
+| Unsupported-platform `OSError` | The runtime lacks required POSIX, `fcntl`, FIFO, no-follow, or positional-I/O support. | Run on a POSIX system that exposes every required capability; there is no insecure fallback. |
+| Directory, FIFO, symlink, hard-link, or ownership error | The mount, UID, mode, or existing artifacts violate the private-channel contract. | Stop endpoints, inspect all three artifacts and ancestors, correct the mount or ownership, then remove stale artifacts together only when unused. |
+| Producer logs `falling back to normal DTPS delivery` | The SHM writer could not encode, open, validate, resize, or write the channel. | Inspect the preceding warning. Direct context publishing uses HTTP, a publisher object uses its WebSocket, and a create-side context uses its local object queue. Normal subscribers can receive the fallback; SHM-only subscribers cannot. |
+| SHM-only subscriber starts but receives no data | Paths differ, the producer uses normal delivery, a second SHM reader consumes FIFO tokens, or no payload has been committed. | Verify the exact base path, enable SHM on the producer, keep one SHM reader, and use `deliver_current=True` when a retained value is expected. |
+| First callback is unexpectedly old | `deliver_current=True` delivers the retained snapshot on startup. | Use `start(deliver_current=False)` for a fresh low-level reader session. |
+| Missing intermediate values or repeated latest values | This is latest-value behavior, FIFO wake-up coalescing, or a slow callback queue. | Design around the newest state, or use normal DTPS or another reliable queue when every event matters. |
+| Writer pauses during publish | A cooperating reader holds the shared lock while copying, or the writer is resizing the channel. | Keep work outside low-level callbacks and avoid repeated oversized payload growth. |
+
+## Benchmarking
+
+[`benchmark_http_vs_websocket_vs_shm.py`](../../../python-benchmark-scripts/benchmark_http_vs_websocket_vs_shm.py)
+is a manual benchmark for comparing three confirmed DTPS delivery paths on one
+host:
+
+| Result `transport` | Publisher path | Subscriber path |
+| --- | --- | --- |
+| `http-direct` | `DTPSContext.publish()` sends one HTTP POST per message. | Normal inline WebSocket subscription. |
+| `websocket-publisher` | `DTPSContext.publisher()` sends messages through a persistent WebSocket. | Normal inline WebSocket subscription. |
+| `shm` | `DTPSContext.publish(..., shm_only=True)` writes to the SHM channel. | `subscribe(..., shm_only=True)` reads the SHM channel. |
+
+The WebSocket publisher is created before warmup, so connection setup is not
+included in its measured samples. The report's `transport_paths` object records
+the complete publisher-to-subscriber path for every result.
+
+From the repository root, run it in an environment with the project
+dependencies installed:
+
+```bash
+PYTHONPATH=src python3 python-benchmark-scripts/benchmark_http_vs_websocket_vs_shm.py \
+  --output-json /tmp/dtps-http-vs-websocket-vs-shm.json
+```
+
+By default, it measures 100 samples after 20 warmups for 1 KiB, 64 KiB, and
+1,000,000-byte payloads. Repeat `--payload-size` to select a different set of
+sizes, and use `--samples`, `--warmup`, and `--timeout` to tune a run. The
+three-way comparison requires a payload from 16 bytes up to, but not including,
+1,048,576 bytes because the direct HTTP path uses the local aiohttp server's
+default request-body limit.
+
+The report includes these metrics:
+
+| Metric | Meaning |
+| --- | --- |
+| `transport_paths` | Machine-readable descriptions of the complete direct HTTP, WebSocket-publisher, and SHM paths. |
+| `confirmed_messages_per_second` | Samples divided by the measured wall-clock interval. Each sample waits for its matching subscriber callback before the next publication. |
+| `publish_to_callback_latency_us` | Time from immediately before constructing and publishing a `RawData` value until the matching subscriber callback runs. It includes local payload construction and the selected high-level publish API path. |
+| `publish_duration_us` | Time from immediately before constructing a `RawData` value until the selected direct or publisher-object `publish()` call returns. |
+
+This is a same-process, same-host microbenchmark. It exercises a remote DTPS
+client context but does not measure cross-process scheduling, remote-network
+delivery, or end-to-end application pipelines such as camera capture and
+decoding. It also serializes publication and confirmation, so it measures
+confirmed latest-value delivery rather than burst behavior or reliable queue
+throughput. Repeat it on target hardware before treating small deltas as
+meaningful.
+
+## Tests
+
+Run the regression suite from the `lib-dtps-http` repository root:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 src/dtps_http_tests/test_shm.py
+```
+
+The suite covers remapping, cross-process locking, FIFO backpressure,
+fresh-session behavior, and reader lifecycle handling. It creates all channel
+files in temporary directories. Run it in an environment with the
+`dtps-http` project dependencies installed.
+
+The DTPS integration suite covers RawData metadata preservation, mirrored and
+SHM-only publishing, duplicate-callback avoidance, and subscription teardown:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest dtps_tests.test_shm
+```

--- a/python-benchmark-scripts/benchmark_http_vs_websocket_vs_shm.py
+++ b/python-benchmark-scripts/benchmark_http_vs_websocket_vs_shm.py
@@ -1,0 +1,660 @@
+# ruff: noqa: INP001
+"""Compare local DTPS direct HTTP, WebSocket-publisher, and SHM delivery.
+
+The direct HTTP path calls ``DTPSContext.publish()``, which sends each message
+as an HTTP POST over a Unix-domain socket. The WebSocket path creates a
+``DTPSContext.publisher()`` and publishes through its persistent WebSocket.
+Both normal paths receive inline events through a WebSocket subscription. The
+SHM path uses the same remote publish and subscribe APIs with ``shm_only=True``.
+Each publication waits for its matching callback, so the reported rate
+is confirmed delivery rate rather than producer-only throughput.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import struct
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+from dtps import context_cleanup
+from dtps_http import (
+    MIME_OCTET,
+    Bounds,
+    RawData,
+    make_http_unix_url,
+    parse_url_unescape,
+    url_to_string,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from dtps.ergo_ui import DTPSContext, PublisherInterface
+
+
+LOGGER = logging.getLogger(__name__)
+_MESSAGE_HEADER = struct.Struct("!QQ")
+_DEFAULT_PAYLOAD_SIZES = (1024, 65536, 1_000_000)
+_DEFAULT_SAMPLES = 100
+_DEFAULT_WARMUP = 20
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+_HTTP_REQUEST_BODY_LIMIT_BYTES = 1024 * 1024
+_HTTP_DIRECT_TRANSPORT = "http-direct"
+_HTTP_DIRECT_TRANSPORT_LABEL = "HTTP direct publish"
+_WEBSOCKET_PUBLISHER_TRANSPORT = "websocket-publisher"
+_WEBSOCKET_PUBLISHER_TRANSPORT_LABEL = "WebSocket publisher"
+_SHM_TRANSPORT = "shm"
+_EMPTY_PERCENTILE_VALUES_ERROR = (
+    "Cannot calculate a percentile from no values."
+)
+_EMPTY_TIMING_VALUES_ERROR = "Cannot summarize no timing samples."
+_MEASUREMENT_INTERVAL_ERROR = (
+    "Benchmark measurement interval was not positive."
+)
+_SAMPLES_ERROR = "--samples must be positive."
+_WARMUP_ERROR = "--warmup cannot be negative."
+_TIMEOUT_ERROR = "--timeout must be positive."
+
+
+class BenchmarkError(ValueError):
+    """Raised when benchmark configuration or delivery is invalid."""
+
+
+@dataclass(frozen=True)
+class Delivery:
+    """One subscriber callback annotated with its publisher metadata."""
+
+    sequence: int
+    published_at_ns: int
+    received_at_ns: int
+
+
+@dataclass(frozen=True)
+class MetricSummary:
+    """A latency summary expressed in microseconds."""
+
+    count: int
+    mean_us: float
+    p50_us: float
+    p95_us: float
+    min_us: float
+    max_us: float
+
+
+@dataclass(frozen=True)
+class TransportResult:
+    """Measured delivery metrics for one payload size and transport."""
+
+    transport: str
+    payload_size_bytes: int
+    samples: int
+    confirmed_messages_per_second: float
+    publish_to_callback_latency_us: MetricSummary
+    publish_duration_us: MetricSummary
+
+
+@dataclass(frozen=True)
+class BenchmarkReport:
+    """The portable JSON representation of one benchmark invocation."""
+
+    transport_paths: dict[str, str]
+    configuration: BenchmarkConfiguration
+    notes: list[str]
+    results: list[TransportResult]
+
+
+@dataclass(frozen=True)
+class BenchmarkConfiguration:
+    """Shared options for a benchmark measurement run."""
+
+    samples: int
+    warmup: int
+    timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class BenchmarkContexts:
+    """The DTPS contexts and channel location used by one run."""
+
+    create: DTPSContext
+    use: DTPSContext
+    channel_directory: Path
+    configuration: BenchmarkConfiguration
+
+
+@dataclass(frozen=True)
+class TransportEndpoints:
+    """One transport's publication endpoint and optional SHM channel."""
+
+    use_topic: DTPSContext
+    channel_path: str
+    transport: str
+    publisher: Optional[PublisherInterface]
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile."""
+    if not values:
+        raise BenchmarkError(_EMPTY_PERCENTILE_VALUES_ERROR)
+    ordered_values = sorted(values)
+    last_index = len(ordered_values) - 1
+    position = last_index * percentile
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, last_index)
+    fraction = position - lower_index
+    lower_value = ordered_values[lower_index]
+    upper_value = ordered_values[upper_index]
+    return lower_value + ((upper_value - lower_value) * fraction)
+
+
+def _summarize_ns(values: Sequence[int]) -> MetricSummary:
+    """Convert nanosecond samples into a microsecond summary."""
+    if not values:
+        raise BenchmarkError(_EMPTY_TIMING_VALUES_ERROR)
+    values_us = [value / 1000.0 for value in values]
+    count = len(values_us)
+    return MetricSummary(
+        count=count,
+        mean_us=sum(values_us) / count,
+        p50_us=_percentile(values_us, 0.50),
+        p95_us=_percentile(values_us, 0.95),
+        min_us=min(values_us),
+        max_us=max(values_us),
+    )
+
+
+def _make_payload_buffer(payload_size: int) -> bytearray:
+    """Return a payload buffer with space for metadata."""
+    if payload_size < _MESSAGE_HEADER.size:
+        message = (
+            f"Payload size must be at least {_MESSAGE_HEADER.size} bytes, "
+            f"not {payload_size}."
+        )
+        raise BenchmarkError(message)
+    return bytearray(payload_size)
+
+
+def _set_owner_only_permissions(path: Path, mode: int) -> None:
+    """Set a benchmark-owned path to its intended owner-only mode."""
+    path.chmod(mode)
+
+
+def _validate_http_payload_size(payload_size: int) -> None:
+    """Reject payloads that the direct HTTP path cannot publish."""
+    if payload_size < _HTTP_REQUEST_BODY_LIMIT_BYTES:
+        return
+    message = (
+        "Payload size must be below the direct HTTP request-body limit of "
+        f"{_HTTP_REQUEST_BODY_LIMIT_BYTES} bytes."
+    )
+    raise BenchmarkError(message)
+
+
+def _decode_delivery(raw_data: RawData) -> Delivery:
+    """Decode publication metadata at the point the subscriber runs."""
+    content = raw_data.content
+    if len(content) < _MESSAGE_HEADER.size:
+        message = "Received benchmark payload without its metadata header."
+        raise ValueError(message)
+    sequence, published_at_ns = _MESSAGE_HEADER.unpack_from(content)
+    received_at_ns = time.perf_counter_ns()
+    return Delivery(sequence, published_at_ns, received_at_ns)
+
+
+def _validate_delivery_timestamp(
+    delivery: Delivery,
+    sequence: int,
+    published_at_ns: int,
+) -> None:
+    """Check that the callback carried the published timestamp."""
+    if delivery.published_at_ns == published_at_ns:
+        return
+    message = (
+        "Subscriber received a payload whose timestamp does not match "
+        f"sequence {sequence}."
+    )
+    raise BenchmarkError(message)
+
+
+async def _wait_for_delivery(
+    deliveries: asyncio.Queue,
+    expected_sequence: int,
+    timeout_seconds: float,
+) -> Delivery:
+    """Wait for a callback while ignoring stale retained payloads."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    while True:
+        remaining_seconds = deadline - loop.time()
+        if remaining_seconds <= 0:
+            message = (
+                "Timed out waiting for delivery of benchmark sequence "
+                f"{expected_sequence}."
+            )
+            raise TimeoutError(message)
+        delivery = await asyncio.wait_for(
+            deliveries.get(),
+            timeout=remaining_seconds,
+        )
+        if delivery.sequence == expected_sequence:
+            return delivery
+
+
+@asynccontextmanager
+async def _create_context_pair(
+    socket_path: Path,
+) -> AsyncIterator[tuple[DTPSContext, DTPSContext]]:
+    """Start local DTPS contexts for all benchmark transport paths."""
+    unix_url = make_http_unix_url(str(socket_path))
+    unix_url_string = url_to_string(unix_url)
+    environment = {
+        "DTPS_BASE_benchmarkserver": f"create:{unix_url_string}",
+        "DTPS_BASE_benchmarkclient": unix_url_string,
+    }
+    async with context_cleanup(
+        "benchmarkserver",
+        environment,
+    ) as context_create:
+        await _set_owner_only_unix_socket_permissions(context_create)
+        async with context_cleanup(
+            "benchmarkclient",
+            environment,
+        ) as context_use:
+            yield context_create, context_use
+
+
+async def _set_owner_only_unix_socket_permissions(
+    context: DTPSContext,
+) -> None:
+    """Restore private Unix socket access after a restrictive umask."""
+    for url_string in await context.get_urls():
+        url = parse_url_unescape(url_string)
+        if url.scheme != "http+unix" or url.host is None:
+            continue
+        _set_owner_only_permissions(Path(url.host), 0o600)
+
+
+async def _benchmark_transport(
+    contexts: BenchmarkContexts,
+    payload_size: int,
+    transport: str,
+) -> TransportResult:
+    """Benchmark confirmed delivery for one transport and payload."""
+    context_create = contexts.create
+    context_use = contexts.use
+    configuration = contexts.configuration
+    topic_name = f"benchmark-{transport}-{payload_size}"
+    create_topic_context = context_create / topic_name
+    await create_topic_context.queue_create(
+        bounds=Bounds.max_length(1),
+    )
+    use_topic = context_use / topic_name
+    deliveries: asyncio.Queue = asyncio.Queue()
+
+    async def on_data(raw_data: RawData) -> None:
+        delivery = _decode_delivery(raw_data)
+        deliveries.put_nowait(delivery)
+
+    channel_path = contexts.channel_directory / topic_name
+    channel_path_string = str(channel_path)
+    if transport == _SHM_TRANSPORT:
+        shm_subscription_topic = cast("Any", use_topic)
+        subscription = await shm_subscription_topic.subscribe(
+            on_data,
+            shm_path=channel_path_string,
+            shm_only=True,
+        )
+    elif transport in (
+        _HTTP_DIRECT_TRANSPORT,
+        _WEBSOCKET_PUBLISHER_TRANSPORT,
+    ):
+        subscription = await use_topic.subscribe(on_data)
+    else:
+        message = f"Unsupported transport {transport!r}."
+        raise BenchmarkError(message)
+
+    publisher: Optional[PublisherInterface] = None
+    try:
+        if transport == _WEBSOCKET_PUBLISHER_TRANSPORT:
+            publisher = await use_topic.publisher()
+        endpoints = TransportEndpoints(
+            use_topic,
+            channel_path_string,
+            transport,
+            publisher,
+        )
+        (
+            publish_to_callback_latencies_ns,
+            publish_durations_ns,
+            measurement_started_at_ns,
+            measurement_finished_at_ns,
+        ) = await _measure_transport_samples(
+            contexts,
+            endpoints,
+            deliveries,
+            payload_size,
+        )
+    finally:
+        if publisher is not None:
+            await publisher.terminate()
+        await subscription.unsubscribe()
+
+    elapsed_seconds = (
+        measurement_finished_at_ns - measurement_started_at_ns
+    ) / 1_000_000_000.0
+    if elapsed_seconds <= 0:
+        raise BenchmarkError(_MEASUREMENT_INTERVAL_ERROR)
+    return TransportResult(
+        transport=transport,
+        payload_size_bytes=payload_size,
+        samples=configuration.samples,
+        confirmed_messages_per_second=(
+            configuration.samples / elapsed_seconds
+        ),
+        publish_to_callback_latency_us=_summarize_ns(
+            publish_to_callback_latencies_ns,
+        ),
+        publish_duration_us=_summarize_ns(publish_durations_ns),
+    )
+
+
+async def _measure_transport_samples(
+    contexts: BenchmarkContexts,
+    endpoints: TransportEndpoints,
+    deliveries: asyncio.Queue,
+    payload_size: int,
+) -> tuple[list[int], list[int], int, int]:
+    """Publish each sample and await its subscriber callback."""
+    configuration = contexts.configuration
+    publish_to_callback_latencies_ns: list[int] = []
+    publish_durations_ns: list[int] = []
+    payload_buffer = _make_payload_buffer(payload_size)
+    total_samples = configuration.warmup + configuration.samples
+    measurement_started_at_ns = 0
+    measurement_finished_at_ns = 0
+    for sample_index in range(total_samples):
+        sequence = sample_index + 1
+        published_at_ns = time.perf_counter_ns()
+        _MESSAGE_HEADER.pack_into(
+            payload_buffer,
+            0,
+            sequence,
+            published_at_ns,
+        )
+        raw_data = RawData(
+            content=bytes(payload_buffer),
+            content_type=MIME_OCTET,
+        )
+        if sample_index == configuration.warmup:
+            measurement_started_at_ns = published_at_ns
+
+        if endpoints.transport == _SHM_TRANSPORT:
+            shm_publisher = cast("Any", endpoints.use_topic)
+            await shm_publisher.publish(
+                raw_data,
+                shm_path=endpoints.channel_path,
+                shm_only=True,
+            )
+        elif endpoints.transport == _HTTP_DIRECT_TRANSPORT:
+            await endpoints.use_topic.publish(raw_data)
+        elif endpoints.transport == _WEBSOCKET_PUBLISHER_TRANSPORT:
+            publisher = endpoints.publisher
+            if publisher is None:
+                raise BenchmarkError(
+                    "WebSocket publisher transport has no publisher object."
+                )
+            await publisher.publish(raw_data)
+        else:
+            raise BenchmarkError(
+                f"Unsupported transport {endpoints.transport!r}."
+            )
+        publish_finished_at_ns = time.perf_counter_ns()
+        delivery = await _wait_for_delivery(
+            deliveries,
+            sequence,
+            configuration.timeout_seconds,
+        )
+        _validate_delivery_timestamp(
+            delivery,
+            sequence,
+            published_at_ns,
+        )
+        if sample_index < configuration.warmup:
+            continue
+        publish_to_callback_latencies_ns.append(
+            delivery.received_at_ns - published_at_ns,
+        )
+        publish_durations_ns.append(
+            publish_finished_at_ns - published_at_ns,
+        )
+    measurement_finished_at_ns = time.perf_counter_ns()
+    return (
+        publish_to_callback_latencies_ns,
+        publish_durations_ns,
+        measurement_started_at_ns,
+        measurement_finished_at_ns,
+    )
+
+
+async def _run_benchmark(
+    payload_sizes: Sequence[int],
+    configuration: BenchmarkConfiguration,
+) -> BenchmarkReport:
+    """Run every configured direct HTTP, WebSocket, and SHM benchmark path."""
+    results: list[TransportResult] = []
+    with tempfile.TemporaryDirectory(
+        prefix="dtps-shm-benchmark-",
+    ) as directory:
+        temporary_directory = Path(directory)
+        _set_owner_only_permissions(temporary_directory, 0o700)
+        socket_path = temporary_directory / "node.sock"
+        channel_directory = temporary_directory / "channels"
+        channel_directory.mkdir(mode=0o700)
+        _set_owner_only_permissions(channel_directory, 0o700)
+        async with _create_context_pair(socket_path) as (
+            context_create,
+            context_use,
+        ):
+            contexts = BenchmarkContexts(
+                context_create,
+                context_use,
+                channel_directory,
+                configuration,
+            )
+            for payload_size in payload_sizes:
+                for transport in (
+                    _HTTP_DIRECT_TRANSPORT,
+                    _WEBSOCKET_PUBLISHER_TRANSPORT,
+                    _SHM_TRANSPORT,
+                ):
+                    result = await _benchmark_transport(
+                        contexts,
+                        payload_size,
+                        transport,
+                    )
+                    results.append(result)
+    notes = [
+        (
+            "HTTP direct publish calls DTPSContext.publish(), which uses an "
+            "HTTP POST over a Unix-domain socket. Its confirmation subscriber "
+            "receives inline events through a WebSocket."
+        ),
+        (
+            "WebSocket publisher creates DTPSContext.publisher() before "
+            "warmup and publishes through its persistent WebSocket. Its "
+            "confirmation subscriber also receives inline WebSocket events."
+        ),
+        "SHM uses a temporary, owner-only channel and latest-value semantics.",
+        (
+            "Each sample waits for its matching callback, so SHM wake-up "
+            "coalescing does not hide drops."
+        ),
+        (
+            "Publish-to-callback latency includes local payload serialization "
+            "and the selected high-level publish API path."
+        ),
+        (
+            "Both DTPS contexts run in this process; this is not a "
+            "cross-process scheduling benchmark."
+        ),
+        (
+            "Run multiple times on target hardware before treating small "
+            "deltas as meaningful."
+        ),
+    ]
+    return BenchmarkReport(
+        transport_paths={
+            _HTTP_DIRECT_TRANSPORT: (
+                "Direct DTPS HTTP POST publisher to inline WebSocket "
+                "subscriber over a Unix-domain socket"
+            ),
+            _WEBSOCKET_PUBLISHER_TRANSPORT: (
+                "Persistent DTPS WebSocket publisher to inline WebSocket "
+                "subscriber over a Unix-domain socket"
+            ),
+            _SHM_TRANSPORT: "SHM-only publisher to SHM-only subscriber",
+        },
+        configuration=configuration,
+        notes=notes,
+        results=results,
+    )
+
+
+def _configure_logging() -> None:
+    """Configure concise command-line benchmark output."""
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+
+def _log_result(result: TransportResult) -> None:
+    """Write one readable transport result to the command line."""
+    publish_to_callback = result.publish_to_callback_latency_us
+    publish_duration = result.publish_duration_us
+    transport_label = _HTTP_DIRECT_TRANSPORT_LABEL
+    if result.transport == _WEBSOCKET_PUBLISHER_TRANSPORT:
+        transport_label = _WEBSOCKET_PUBLISHER_TRANSPORT_LABEL
+    if result.transport == _SHM_TRANSPORT:
+        transport_label = "SHM"
+    LOGGER.info(
+        "%s %d B: %.1f confirmed msg/s | publish-to-callback mean %.2f us, "
+        "p95 %.2f us, max %.2f us | publish mean %.2f us",
+        transport_label,
+        result.payload_size_bytes,
+        result.confirmed_messages_per_second,
+        publish_to_callback.mean_us,
+        publish_to_callback.p95_us,
+        publish_to_callback.max_us,
+        publish_duration.mean_us,
+    )
+
+
+def _parse_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
+    """Parse command-line configuration for the manual benchmark."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare direct DTPS HTTP publication, persistent WebSocket "
+            "publication, and shared-memory delivery over a Unix-domain "
+            "socket."
+        ),
+    )
+    parser.add_argument(
+        "--payload-size",
+        action="append",
+        type=int,
+        dest="payload_sizes",
+        help=(
+            "Payload size in bytes; repeat for multiple sizes. Defaults to "
+            "1 KiB, 64 KiB, and 1,000,000 bytes."
+        ),
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=_DEFAULT_SAMPLES,
+        help=f"Measured samples per transport; default {_DEFAULT_SAMPLES}.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=_DEFAULT_WARMUP,
+        help=f"Discarded samples per transport; default {_DEFAULT_WARMUP}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help=(
+            "Maximum seconds to wait for each subscriber callback; default "
+            f"{_DEFAULT_TIMEOUT_SECONDS}."
+        ),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path for the complete machine-readable report.",
+    )
+    return parser, parser.parse_args()
+
+
+def _validate_arguments(args: argparse.Namespace) -> list[int]:
+    """Validate options and return the selected payload sizes."""
+    payload_sizes = args.payload_sizes
+    if payload_sizes is None:
+        payload_sizes = list(_DEFAULT_PAYLOAD_SIZES)
+    if args.samples <= 0:
+        raise BenchmarkError(_SAMPLES_ERROR)
+    if args.warmup < 0:
+        raise BenchmarkError(_WARMUP_ERROR)
+    if args.timeout <= 0:
+        raise BenchmarkError(_TIMEOUT_ERROR)
+    for payload_size in payload_sizes:
+        _make_payload_buffer(payload_size)
+        _validate_http_payload_size(payload_size)
+    return payload_sizes
+
+
+def _write_report(path: Path, report: BenchmarkReport) -> None:
+    """Write the report and create any missing parent directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(asdict(report), indent=2, sort_keys=True)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    """Run the selected benchmark pairs and optionally save results."""
+    _configure_logging()
+    parser, args = _parse_arguments()
+    try:
+        payload_sizes = _validate_arguments(args)
+    except BenchmarkError as error:
+        parser.error(str(error))
+    configuration = BenchmarkConfiguration(
+        samples=args.samples,
+        warmup=args.warmup,
+        timeout_seconds=args.timeout,
+    )
+    report = asyncio.run(
+        _run_benchmark(
+            payload_sizes,
+            configuration,
+        )
+    )
+    for result in report.results:
+        _log_result(result)
+    output_path = args.output_json
+    if output_path is not None:
+        _write_report(output_path, report)
+        LOGGER.info("Saved report to %s", output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dtps/ergo_create.py
+++ b/src/dtps/ergo_create.py
@@ -1,7 +1,7 @@
 import asyncio
 import traceback
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Awaitable, Callable, cast, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, AsyncIterator, Awaitable, Callable, cast, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from jsonpatch import JsonPatch
 
@@ -54,6 +54,8 @@ __all__ = [
     "ContextManagerCreate",
 ]
 
+_ERROR_CONTEXT_MANAGER_CLOSING = "Context manager is closing."
+
 
 class ContextManagerCreate(ContextManager):
     dtps_server_wrap: Optional[ServerWrapped]
@@ -65,6 +67,8 @@ class ContextManagerCreate(ContextManager):
         self.dtps_server_wrap = None
         self.contexts = {}
         self.base_config = ContextConfig.default()
+        self._subscriptions: Set[SubscriptionInterface] = set()
+        self._closing = False
         assert self.context_info.is_create()
 
     async def init(self) -> None:
@@ -83,8 +87,53 @@ class ContextManagerCreate(ContextManager):
         self.dtps_server_wrap = a
 
     async def aclose(self) -> None:
-        if self.dtps_server_wrap is not None:
-            await self.dtps_server_wrap.aclose()
+        self._closing = True
+        try:
+            await self._unsubscribe_all()
+        finally:
+            if self.dtps_server_wrap is not None:
+                await self.dtps_server_wrap.aclose()
+
+    async def remember_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Keep a subscription alive only until manager shutdown."""
+        if not self._closing:
+            self._subscriptions.add(subscription)
+            return
+        await subscription.unsubscribe()
+        raise RuntimeError(_ERROR_CONTEXT_MANAGER_CLOSING)
+
+    def forget_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Release an unsubscribed handle from manager ownership."""
+        self._subscriptions.discard(subscription)
+
+    async def _unsubscribe_all(self) -> None:
+        """Stop every active subscription before the server closes."""
+        subscriptions = list(self._subscriptions)
+        self._subscriptions.clear()
+        first_error: Optional[Exception] = None
+        for subscription in subscriptions:
+            error = await self._unsubscribe_subscription(subscription)
+            if error is not None and first_error is None:
+                first_error = error
+        if first_error is not None:
+            raise first_error
+
+    @staticmethod
+    async def _unsubscribe_subscription(
+        subscription: SubscriptionInterface,
+    ) -> Optional[Exception]:
+        """Stop one subscription and return a cleanup failure."""
+        try:
+            await subscription.unsubscribe()
+        except Exception as error:  # noqa: BLE001
+            return error
+        return None
 
     def get_context_by_components(self, components: Tuple[str, ...], config: ContextConfig) -> "DTPSContext":
         key = components, config
@@ -117,12 +166,37 @@ class ContextManagerCreateContextPublisher(PublisherInterface):
 
 
 class ContextManagerCreateContextSubscriber(SubscriptionInterface):
-    def __init__(self, sub_id: SUB_ID, oq0: ObjectQueue) -> None:
+    def __init__(
+        self,
+        master: ContextManagerCreate,
+        sub_id: SUB_ID,
+        oq0: ObjectQueue,
+        processor_task: "asyncio.Task[None]",
+        processor_stop_event: asyncio.Event,
+    ) -> None:
+        self._master = master
         self.sub_id = sub_id
         self.oq0 = oq0
+        self._processor_task = processor_task
+        self._processor_stop_event = processor_stop_event
+        self._closed = False
 
     async def unsubscribe(self) -> None:
-        await self.oq0.unsubscribe(self.sub_id)
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self.oq0.unsubscribe(self.sub_id)
+        finally:
+            self._processor_stop_event.set()
+            processor_task = self._processor_task
+            if processor_task is not asyncio.current_task():
+                processor_task.cancel()
+                await asyncio.gather(
+                    processor_task,
+                    return_exceptions=True,
+                )
+            self._master.forget_subscription(self)
 
 
 class ContextManagerCreateContext(DTPSContext):
@@ -252,6 +326,8 @@ class ContextManagerCreateContext(DTPSContext):
 
         queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
 
+        processor_stop_event = asyncio.Event()
+
         async def _processor():
             while True:
                 data: RawData = await queue.get()
@@ -263,9 +339,8 @@ class ContextManagerCreateContext(DTPSContext):
                     print(f"Exception in user callback for queue {self}:")
                     traceback.print_exc()
                 # <== this block runs user code, we need to catch exceptions
-
-        # create processor task
-        asyncio.run_coroutine_threadsafe(_processor(), asyncio.get_event_loop())
+                if processor_stop_event.is_set():
+                    return
 
         async def _wrapped_on_data(data: RawData):
             try:
@@ -288,7 +363,26 @@ class ContextManagerCreateContext(DTPSContext):
         _ = inline
         sub_id = oq0.subscribe(wrap, max_frequency=max_frequency)
 
-        return ContextManagerCreateContextSubscriber(sub_id, oq0)
+        processor = _processor()
+        try:
+            processor_task = asyncio.create_task(processor)
+        except BaseException:
+            processor.close()
+            await oq0.unsubscribe(sub_id)
+            raise
+        subscription = ContextManagerCreateContextSubscriber(
+            self.master,
+            sub_id,
+            oq0,
+            processor_task,
+            processor_stop_event,
+        )
+        try:
+            await self.master.remember_subscription(subscription)
+        except BaseException:
+            await subscription.unsubscribe()
+            raise
+        return subscription
 
     async def history(self) -> "Optional[HistoryInterface]":
         # TODO: DTSW-4794: implement history

--- a/src/dtps/ergo_create.py
+++ b/src/dtps/ergo_create.py
@@ -49,6 +49,13 @@ from .ergo_ui import (
     ServeFunction,
     SubscriptionInterface,
 )
+from .shm import (
+    ShmWriterPool,
+    create_shm_subscription,
+    should_publish_http,
+    validate_max_frequency,
+    validate_shm_configuration,
+)
 
 __all__ = [
     "ContextManagerCreate",
@@ -67,6 +74,7 @@ class ContextManagerCreate(ContextManager):
         self.dtps_server_wrap = None
         self.contexts = {}
         self.base_config = ContextConfig.default()
+        self._shm_writers = ShmWriterPool()
         self._subscriptions: Set[SubscriptionInterface] = set()
         self._closing = False
         assert self.context_info.is_create()
@@ -91,8 +99,11 @@ class ContextManagerCreate(ContextManager):
         try:
             await self._unsubscribe_all()
         finally:
-            if self.dtps_server_wrap is not None:
-                await self.dtps_server_wrap.aclose()
+            try:
+                self._shm_writers.close()
+            finally:
+                if self.dtps_server_wrap is not None:
+                    await self.dtps_server_wrap.aclose()
 
     async def remember_subscription(
         self,
@@ -153,9 +164,9 @@ class ContextManagerCreateContextPublisher(PublisherInterface):
     def __init__(self, master: "ContextManagerCreateContext"):
         self.master = master
 
-    async def publish(self, rd: RawData, /) -> None:
+    async def publish(self, rd: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
         # nothing more to do for this
-        await self.master.publish(rd)
+        await self.master.publish(rd, shm_path=shm_path, shm_only=shm_only)
 
     async def terminate(self) -> None:
         # nothing more to do for this
@@ -319,7 +330,27 @@ class ContextManagerCreateContext(DTPSContext):
         max_frequency: Optional[float] = None,
         inline: bool = True,
         queue_size: int = DEFAULT_CALLBACK_QUEUE_SIZE,
+        *,
+        shm_path: Optional[str] = None,
+        shm_only: bool = False,
     ) -> "SubscriptionInterface":
+        validate_shm_configuration(shm_path, shm_only)
+        validate_max_frequency(max_frequency)
+        if shm_only and shm_path:
+            subscription = create_shm_subscription(
+                on_data,
+                shm_path,
+                queue_size,
+                max_frequency=max_frequency,
+                on_unsubscribe=self.master.forget_subscription,
+            )
+            try:
+                await self.master.remember_subscription(subscription)
+            except BaseException:
+                await subscription.unsubscribe()
+                raise
+            return subscription
+
         oq0 = self._get_server().get_oq(self._topic)
 
         when = EveryOnceInAWhile(1.0 / max_frequency if max_frequency is not None else 0)
@@ -388,7 +419,9 @@ class ContextManagerCreateContext(DTPSContext):
         # TODO: DTSW-4794: implement history
         raise NotImplementedError()
 
-    async def publish(self, data: RawData, /) -> None:
+    async def publish(self, data: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
+        if not should_publish_http(self.master._shm_writers, data, shm_path=shm_path, shm_only=shm_only):
+            return
         server = self._get_server()
         topic = self._topic
         queue = server.get_oq(topic)

--- a/src/dtps/ergo_ui.py
+++ b/src/dtps/ergo_ui.py
@@ -161,10 +161,17 @@ class DTPSContext(ABC):
         max_frequency: Optional[float] = None,
         inline: bool = True,
         queue_size: int = DEFAULT_CALLBACK_QUEUE_SIZE,
+        *,
+        shm_path: Optional[str] = None,
+        shm_only: bool = False,
     ) -> "SubscriptionInterface":
         """
         The subscription is persistent: if the topic is not available, we wait until
         it is (up to a timeout).
+
+        When ``shm_path`` is provided with ``shm_only=True``, the callback
+        receives the local latest-value shared-memory channel instead of the
+        normal DTPS delivery path.
         """
         ...
 
@@ -189,9 +196,14 @@ class DTPSContext(ABC):
     # pushing
 
     @abstractmethod
-    async def publish(self, data: RawData, /) -> None:
-        """Publishes data to the resource. Meant to be used for infrequent pushes.
-        For frequent pushes, use the publisher interface."""
+    async def publish(self, data: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
+        """Publish data through the normal DTPS path and optionally SHM.
+
+        When ``shm_path`` is set, the message is also attempted on that
+        latest-value shared-memory channel. With ``shm_only=True``, a
+        successful SHM write suppresses normal delivery; a failed SHM write
+        uses normal delivery as a fallback.
+        """
         ...
 
     @abstractmethod
@@ -343,8 +355,13 @@ class ConnectionInterface(ABC):
 @dataclass
 class PublisherInterface(ABC):
     @abstractmethod
-    async def publish(self, rd: RawData, /) -> None:
-        """Publishes data to the resource"""
+    async def publish(self, rd: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
+        """Publish data through the normal path and optionally SHM.
+
+        With ``shm_only=True``, a successful SHM write suppresses this
+        publisher's normal path; a failed SHM write uses that path as a
+        fallback.
+        """
         ...
 
     @abstractmethod

--- a/src/dtps/ergo_use.py
+++ b/src/dtps/ergo_use.py
@@ -460,7 +460,11 @@ class ContextManagerUseContext(DTPSContext):
 
     def _get_frequency_publishing(self) -> float:
         now = time.time()
-        while self.last_published[0] < now - WARN_USE_PUBLISH_CONTEXT_HORIZON_S:
+        while (
+            self.last_published
+            and self.last_published[0]
+            < now - WARN_USE_PUBLISH_CONTEXT_HORIZON_S
+        ):
             self.last_published.pop(0)
         if not self.last_published:
             return 0.0

--- a/src/dtps/ergo_use.py
+++ b/src/dtps/ergo_use.py
@@ -397,15 +397,42 @@ WARN_USE_PUBLISH_CONTEXT_N_MIN = 4
 
 class FakeSubscriptionInterface(SubscriptionInterface):
     real: Optional[SubscriptionInterface]
+    _finished_event: Event
 
     def __init__(self, event: Event):
         self.real = None
         self.unsubscribe_event = event
+        self._finished_event = Event()
+        self._real_unsubscribed = False
+
+    async def set_real(
+        self,
+        subscription: SubscriptionInterface,
+        finished_event: Event,
+    ) -> bool:
+        """Set the active subscription and stop it when cancelled."""
+        self.real = subscription
+        self._finished_event = finished_event
+        self._real_unsubscribed = False
+        if not self.unsubscribe_event.is_set():
+            return False
+        finished_event.set()
+        await self._unsubscribe_real()
+        return True
+
+    async def _unsubscribe_real(self) -> None:
+        """Stop the current real subscription at most once."""
+        real = self.real
+        if real is None or self._real_unsubscribed:
+            return
+        self._real_unsubscribed = True
+        await real.unsubscribe()
 
     async def unsubscribe(self) -> None:
         self.unsubscribe_event.set()
-        if self.real is not None:
-            await self.real.unsubscribe()
+        finished_event = self._finished_event
+        finished_event.set()
+        await self._unsubscribe_real()
 
 
 class ContextManagerUseContext(DTPSContext):
@@ -550,7 +577,7 @@ class ContextManagerUseContext(DTPSContext):
         logger.debug(f"subscribe _subscribe_patient_task: starting")
         ntries = 0
         nsuccess = 0
-        while True:
+        while not fldi.unsubscribe_event.is_set():
             logger.debug(f"_subscribe_patient_task patient: loop {ntries=} {nsuccess=}")
             try:
                 finished_event = Event()
@@ -563,14 +590,22 @@ class ContextManagerUseContext(DTPSContext):
                 si = await self.subscribe_once(on_data, max_frequency, inline, on_finished=on_finished,
                                                queue_size=queue_size)
                 nsuccess += 1
-                fldi.real = si
+                unsubscribe_requested = await fldi.set_real(
+                    si,
+                    finished_event,
+                )
+                if unsubscribe_requested:
+                    break
                 logger.debug(f"_subscribe_patient_task: wait for finished_event")
                 await finished_event.wait()
+                if fldi.unsubscribe_event.is_set():
+                    break
                 await asyncio.sleep(1)
                 if fldi.unsubscribe_event.is_set():
                     break
                 # await fldi.unsubscribe_event.wait()
             except asyncio.CancelledError:
+                await fldi.unsubscribe()
                 raise
             except CannotConnectToAnyURL:
                 logger.debug(f"_subscribe_patient_task: cannot connect yet, retrying")
@@ -578,6 +613,8 @@ class ContextManagerUseContext(DTPSContext):
             except Exception as e:  # ok but which error?
                 logger.error(f"_subscribe_patient_task: Error in subscribe: {e}")
                 await asyncio.sleep(1)
+
+        await fldi.unsubscribe()
 
     async def subscribe_once(
         self,

--- a/src/dtps/ergo_use.py
+++ b/src/dtps/ergo_use.py
@@ -65,6 +65,13 @@ from .ergo_ui import (
     ServeFunction,
     SubscriptionInterface,
 )
+from .shm import (
+    ShmWriterPool,
+    create_shm_subscription,
+    should_publish_http,
+    validate_max_frequency,
+    validate_shm_configuration,
+)
 
 PS = ParamSpec("PS")
 
@@ -107,7 +114,9 @@ class ContextManagerUse(ContextManager):
         self.tasks = []
         self._tasks_lock = Lock()
         self._closing = False
+        self._shm_writers = ShmWriterPool()
         self._subscriptions: Set[SubscriptionInterface] = set()
+        self._shm_subscriptions: Set[SubscriptionInterface] = set()
 
     def remember_task(self, task: "asyncio.Task[Any]") -> None:
         """Register a task for manager shutdown."""
@@ -188,6 +197,48 @@ class ContextManagerUse(ContextManager):
             await subscription.unsubscribe()
         except Exception:  # noqa: BLE001
             logger.exception("Failed to stop DTPS subscription.")
+
+    async def remember_shm_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Register a shared-memory reader for manager shutdown."""
+        with self._tasks_lock:
+            closing = self._closing
+            if not closing:
+                self._shm_subscriptions.add(subscription)
+        if not closing:
+            return
+        await subscription.unsubscribe()
+        raise RuntimeError(_ERROR_CONTEXT_MANAGER_CLOSING)
+
+    def forget_shm_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Release a stopped SHM reader from manager ownership."""
+        with self._tasks_lock:
+            self._shm_subscriptions.discard(subscription)
+
+    async def _unsubscribe_shm_subscriptions(self) -> None:
+        """Stop active shared-memory readers before client shutdown."""
+        with self._tasks_lock:
+            subscriptions = list(self._shm_subscriptions)
+            self._shm_subscriptions.clear()
+        for subscription in subscriptions:
+            await self._unsubscribe_shm_subscription(subscription)
+
+    @staticmethod
+    async def _unsubscribe_shm_subscription(
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Stop one SHM reader without interrupting shutdown."""
+        try:
+            await subscription.unsubscribe()
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to stop DTPS shared-memory subscription."
+            )
 
     @staticmethod
     def _cancel_task_on_own_loop(task: "asyncio.Task[Any]") -> None:
@@ -296,11 +347,14 @@ class ContextManagerUse(ContextManager):
             self._closing = True
         try:
             await self._unsubscribe_subscriptions()
+            await self._unsubscribe_shm_subscriptions()
             await self._cancel_and_wait_for_tasks()
             await self.client.aclose()
         finally:
             await self._unsubscribe_subscriptions()
+            await self._unsubscribe_shm_subscriptions()
             await self._cancel_and_wait_for_tasks()
+            self._shm_writers.close()
 
     def get_context_by_components(self, components: Tuple[str, ...], config: ContextConfig) -> "DTPSContext":
         key = (components, config)
@@ -337,7 +391,9 @@ class ContextManagerUseContextPublisher(PublisherInterface):
         )
         self._context_manager.remember_task(self.task_push)
 
-    async def publish(self, rd: RawData, /) -> None:
+    async def publish(self, rd: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
+        if not should_publish_http(self._context_manager._shm_writers, rd, shm_path=shm_path, shm_only=shm_only):
+            return
         await self.queue_in.put(rd)
         success = await self.queue_out.get()
         if not success:
@@ -554,7 +610,26 @@ class ContextManagerUseContext(DTPSContext):
         max_frequency: Optional[float] = None,
         inline: bool = True,
         queue_size: int = DEFAULT_CALLBACK_QUEUE_SIZE,
+        *,
+        shm_path: Optional[str] = None,
+        shm_only: bool = False,
     ) -> "SubscriptionInterface":
+        validate_shm_configuration(shm_path, shm_only)
+        validate_max_frequency(max_frequency)
+        if shm_only and shm_path:
+            subscription = create_shm_subscription(
+                on_data,
+                shm_path,
+                queue_size,
+                max_frequency=max_frequency,
+                on_unsubscribe=self.master.forget_shm_subscription,
+            )
+            try:
+                await self.master.remember_shm_subscription(subscription)
+            except BaseException:
+                await subscription.unsubscribe()
+                raise
+            return subscription
         if not self.config.patient:
             return await self.subscribe_once(on_data, max_frequency, inline)
 
@@ -711,7 +786,9 @@ class ContextManagerUseContext(DTPSContext):
         url = join(best_url, topic.as_relative_url())
         return url
 
-    async def publish(self, data: RawData) -> None:
+    async def publish(self, data: RawData, /, *, shm_path: Optional[str] = None, shm_only: bool = False) -> None:
+        if not should_publish_http(self.master._shm_writers, data, shm_path=shm_path, shm_only=shm_only):
+            return
         self.last_published.append(time.time())
         freq = self._get_frequency_publishing()
         url = await self._get_best_url()

--- a/src/dtps/ergo_use.py
+++ b/src/dtps/ergo_use.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    Set,
 )
 
 import cbor2
@@ -73,6 +74,8 @@ __all__ = [
     "ContextManagerUse",
 ]
 
+_ERROR_CONTEXT_MANAGER_CLOSING = "Context manager is closing."
+
 
 class CannotConnectToAnyURL(Exception):
     pass
@@ -104,6 +107,7 @@ class ContextManagerUse(ContextManager):
         self.tasks = []
         self._tasks_lock = Lock()
         self._closing = False
+        self._subscriptions: Set[SubscriptionInterface] = set()
 
     def remember_task(self, task: "asyncio.Task[Any]") -> None:
         """Register a task for manager shutdown."""
@@ -147,6 +151,43 @@ class ContextManagerUse(ContextManager):
             )
         except RuntimeError:
             return
+
+    def remember_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> bool:
+        """Register a normal subscription unless shutdown has started."""
+        with self._tasks_lock:
+            if self._closing:
+                return False
+            self._subscriptions.add(subscription)
+        return True
+
+    def forget_subscription(
+        self,
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Release a stopped normal subscription from manager ownership."""
+        with self._tasks_lock:
+            self._subscriptions.discard(subscription)
+
+    async def _unsubscribe_subscriptions(self) -> None:
+        """Stop normal subscriptions before the client closes."""
+        with self._tasks_lock:
+            subscriptions = list(self._subscriptions)
+            self._subscriptions.clear()
+        for subscription in subscriptions:
+            await self._unsubscribe_subscription(subscription)
+
+    @staticmethod
+    async def _unsubscribe_subscription(
+        subscription: SubscriptionInterface,
+    ) -> None:
+        """Stop one normal subscription without interrupting shutdown."""
+        try:
+            await subscription.unsubscribe()
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to stop DTPS subscription.")
 
     @staticmethod
     def _cancel_task_on_own_loop(task: "asyncio.Task[Any]") -> None:
@@ -254,9 +295,11 @@ class ContextManagerUse(ContextManager):
         with self._tasks_lock:
             self._closing = True
         try:
+            await self._unsubscribe_subscriptions()
             await self._cancel_and_wait_for_tasks()
             await self.client.aclose()
         finally:
+            await self._unsubscribe_subscriptions()
             await self._cancel_and_wait_for_tasks()
 
     def get_context_by_components(self, components: Tuple[str, ...], config: ContextConfig) -> "DTPSContext":
@@ -313,11 +356,37 @@ class ContextManagerUseContextPublisher(PublisherInterface):
 
 
 class ContextManagerUseSubscription(SubscriptionInterface):
-    def __init__(self, ldi: ListenDataInterface):
+    def __init__(
+        self,
+        ldi: ListenDataInterface,
+        processor_task: "asyncio.Task[None]",
+        processor_stop_event: Event,
+        on_unsubscribe: Callable[[SubscriptionInterface], None] | None = None,
+    ):
         self.ldi = ldi
+        self._processor_task = processor_task
+        self._processor_stop_event = processor_stop_event
+        self._on_unsubscribe = on_unsubscribe
+        self._closed = False
 
     async def unsubscribe(self) -> None:
-        await self.ldi.stop()
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self.ldi.stop()
+        finally:
+            self._processor_stop_event.set()
+            processor_task = self._processor_task
+            if processor_task is not asyncio.current_task():
+                processor_task.cancel()
+                await asyncio.gather(
+                    processor_task,
+                    return_exceptions=True,
+                )
+            on_unsubscribe = self._on_unsubscribe
+            if on_unsubscribe is not None:
+                on_unsubscribe(self)
 
 
 # min frequency to warn for
@@ -523,6 +592,8 @@ class ContextManagerUseContext(DTPSContext):
 
         queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
 
+        processor_stop_event = Event()
+
         async def _processor():
             while True:
                 data: RawData = await queue.get()
@@ -534,30 +605,59 @@ class ContextManagerUseContext(DTPSContext):
                     print(f"Exception in user callback for queue {self}:")
                     traceback.print_exc()
                 # <== this block runs user code, we need to catch exceptions
+                if processor_stop_event.is_set():
+                    return
 
-        # create processor task
-        asyncio.run_coroutine_threadsafe(_processor(), asyncio.get_event_loop())
+        processor = _processor()
+        try:
+            processor_task = asyncio.create_task(processor)
+        except BaseException:
+            processor.close()
+            raise
+        try:
+            self.master.remember_task(processor_task)
 
-        async def _wrapped_on_data(data: RawData):
-            try:
-                queue.put_nowait(data)
-            except asyncio.QueueFull:
+            async def _wrapped_on_data(data: RawData):
                 try:
-                    queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    pass
-                queue.put_nowait(data)
+                    queue.put_nowait(data)
+                except asyncio.QueueFull:
+                    try:
+                        queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        pass
+                    queue.put_nowait(data)
 
-        ldi = await self.master.client.listen_url(
-            url,
-            _wrapped_on_data,
-            inline_data=inline,
-            raise_on_error=True,
-            max_frequency=max_frequency,
-            on_finished=on_finished,
-        )
+            ldi = await self.master.client.listen_url(
+                url,
+                _wrapped_on_data,
+                inline_data=inline,
+                raise_on_error=True,
+                max_frequency=max_frequency,
+                on_finished=on_finished,
+            )
+        except BaseException:
+            processor_task.cancel()
+            await asyncio.gather(
+                processor_task,
+                return_exceptions=True,
+            )
+            raise
         # logger.debug(f"subscribed to {url} -> {t}")
-        return ContextManagerUseSubscription(ldi)
+        subscription = ContextManagerUseSubscription(
+            ldi,
+            processor_task,
+            processor_stop_event,
+            self.master.forget_subscription,
+        )
+        try:
+            registered = self.master.remember_subscription(subscription)
+        except BaseException:
+            await subscription.unsubscribe()
+            raise
+        if registered:
+            return subscription
+        await subscription.unsubscribe()
+        raise RuntimeError(_ERROR_CONTEXT_MANAGER_CLOSING)
 
     async def history(self) -> "Optional[HistoryInterface]":
         # TODO: DTSW-4803: [use] implement history

--- a/src/dtps/ergo_use.py
+++ b/src/dtps/ergo_use.py
@@ -4,6 +4,7 @@ import traceback
 from asyncio import CancelledError, Event
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from threading import Lock
 from typing import (
     Any,
     AsyncIterator,
@@ -90,6 +91,7 @@ class ContextManagerUse(ContextManager):
     client: DTPSClient
     contexts: "Dict[Tuple[Tuple[str, ...], ContextConfig], ContextManagerUseContext]"
     tasks: List["asyncio.Task[Any]"]
+    _closing: bool
 
     def __init__(self, base_name: str, context_info: "ContextInfo"):
         self.client = DTPSClient(nickname=base_name, shutdown_event=None)
@@ -100,9 +102,83 @@ class ContextManagerUse(ContextManager):
         assert not self.context_info.is_create()
         self.last_connection = None
         self.tasks = []
+        self._tasks_lock = Lock()
+        self._closing = False
 
     def remember_task(self, task: "asyncio.Task[Any]") -> None:
-        self.tasks.append(task)
+        """Register a task for manager shutdown."""
+        with self._tasks_lock:
+            self.tasks.append(task)
+            closing = self._closing
+        self._forget_task_when_done(task)
+        if closing:
+            self._cancel_task_on_own_loop(task)
+
+    def forget_task(self, task: "asyncio.Task[Any]") -> None:
+        """Release a completed task from manager ownership."""
+        with self._tasks_lock:
+            self.tasks = [
+                candidate for candidate in self.tasks if candidate is not task
+            ]
+
+    def _handle_task_completion(self, task: "asyncio.Task[Any]") -> None:
+        """Log a background task failure before releasing it."""
+        try:
+            if not task.cancelled():
+                error = task.exception()
+                if error is not None:
+                    logger.error(
+                        "DTPS background task failed.",
+                        exc_info=(
+                            type(error),
+                            error,
+                            error.__traceback__,
+                        ),
+                    )
+        finally:
+            self.forget_task(task)
+
+    def _forget_task_when_done(self, task: "asyncio.Task[Any]") -> None:
+        """Install task cleanup from the event loop that owns it."""
+        try:
+            task.get_loop().call_soon_threadsafe(
+                task.add_done_callback,
+                self._handle_task_completion,
+            )
+        except RuntimeError:
+            return
+
+    @staticmethod
+    def _cancel_task_on_own_loop(task: "asyncio.Task[Any]") -> None:
+        """Schedule task cancellation on the event loop that owns it."""
+        task_loop = task.get_loop()
+        cancel_task = task.cancel
+        try:
+            task_loop.call_soon_threadsafe(cancel_task)
+        except RuntimeError:
+            return
+
+    async def _cancel_and_wait_for_tasks(self) -> None:
+        """Cancel all tasks registered during shutdown."""
+        current_loop = asyncio.get_running_loop()
+        while True:
+            with self._tasks_lock:
+                if not self.tasks:
+                    return
+                tasks = self.tasks
+                self.tasks = []
+            current_loop_tasks: List["asyncio.Task[Any]"] = []
+            for task in tasks:
+                if task.get_loop() is current_loop:
+                    task.cancel()
+                    current_loop_tasks.append(task)
+                else:
+                    self._cancel_task_on_own_loop(task)
+            if current_loop_tasks:
+                await asyncio.gather(
+                    *current_loop_tasks,
+                    return_exceptions=True,
+                )
 
     async def init(self) -> None:
         await self.client.init()
@@ -175,9 +251,13 @@ class ContextManagerUse(ContextManager):
         # return best_url
 
     async def aclose(self) -> None:
-        await self.client.aclose()
-        for t in self.tasks:
-            t.cancel()
+        with self._tasks_lock:
+            self._closing = True
+        try:
+            await self._cancel_and_wait_for_tasks()
+            await self.client.aclose()
+        finally:
+            await self._cancel_and_wait_for_tasks()
 
     def get_context_by_components(self, components: Tuple[str, ...], config: ContextConfig) -> "DTPSContext":
         key = (components, config)
@@ -196,17 +276,23 @@ class ContextManagerUseContextPublisher(PublisherInterface):
     queue_out: "asyncio.Queue[bool]"
     task_push: "asyncio.Task[Any]"
 
-    def __init__(self, master: "ContextManagerUseContext"):
-        self.master = master
+    def __init__(
+        self,
+        context: "ContextManagerUseContext",
+        context_manager: ContextManagerUse,
+    ):
+        self._context = context
+        self._context_manager = context_manager
 
         self.queue_in = asyncio.Queue()
         self.queue_out = asyncio.Queue()
 
     async def init(self) -> None:
-        url_topic = await self.master._get_best_url()
-        self.task_push = await self.master.master.client.push_continuous(
+        url_topic = await self._context._get_best_url()
+        self.task_push = await self._context_manager.client.push_continuous(
             url_topic, queue_in=self.queue_in, queue_out=self.queue_out
         )
+        self._context_manager.remember_task(self.task_push)
 
     async def publish(self, rd: RawData, /) -> None:
         await self.queue_in.put(rd)
@@ -216,6 +302,10 @@ class ContextManagerUseContextPublisher(PublisherInterface):
 
     async def terminate(self) -> None:
         self.task_push.cancel()
+        await asyncio.gather(
+            self.task_push,
+            return_exceptions=True,
+        )
 
     async def get_listener_info(self) -> Optional[ListenerInfo]:
         # Not available for remote contexts
@@ -495,7 +585,8 @@ class ContextManagerUseContext(DTPSContext):
         await self.master.client.publish(url, data)
 
     async def publisher(self) -> "ContextManagerUseContextPublisher":
-        publisher = ContextManagerUseContextPublisher(self)
+        context_manager = self.master
+        publisher = ContextManagerUseContextPublisher(self, context_manager)
         await publisher.init()
         return publisher
 

--- a/src/dtps/shm.py
+++ b/src/dtps/shm.py
@@ -1,0 +1,340 @@
+"""Optional shared-memory transport for DTPS ``RawData`` messages."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from contextlib import suppress
+from threading import Lock
+from typing import Awaitable, Callable
+
+import cbor2
+
+from dtps_http import ContentType, EveryOnceInAWhile, RawData
+from dtps_http.shm import ShmReader, ShmWriter
+
+from . import logger
+from .ergo_ui import SubscriptionInterface
+
+__all__ = [
+    "ShmWriterPool",
+    "create_shm_subscription",
+    "decode_shm_raw_data",
+    "encode_shm_raw_data",
+    "should_publish_http",
+    "validate_max_frequency",
+    "validate_shm_configuration",
+]
+
+_WIRE_CONTENT = "content"
+_WIRE_CONTENT_TYPE = "content_type"
+_WIRE_VERSION = "version"
+_WIRE_VERSION_VALUE = 1
+_ERROR_SHM_PATH_REQUIRED = "shm_path is required when shm_only is True."
+_ERROR_PAYLOAD_NOT_MAPPING = "DTPS shared-memory payload is not a mapping."
+_ERROR_PAYLOAD_VERSION = "Unsupported DTPS shared-memory payload version."
+_ERROR_PAYLOAD_CONTENT = "DTPS shared-memory payload content is not bytes."
+_ERROR_PAYLOAD_CONTENT_TYPE = (
+    "DTPS shared-memory payload content type is not text."
+)
+_ERROR_MAX_FREQUENCY = "max_frequency must be a finite positive number."
+
+
+def validate_shm_configuration(
+    shm_path: str | None,
+    shm_only: bool,  # noqa: FBT001
+) -> None:
+    """Reject an SHM-only request that does not identify a channel."""
+    if shm_only and not shm_path:
+        raise ValueError(_ERROR_SHM_PATH_REQUIRED)
+
+
+def validate_max_frequency(max_frequency: float | None) -> None:
+    """Reject subscription rate limits that cannot define an interval."""
+    if max_frequency is None:
+        return
+    if not math.isfinite(max_frequency) or max_frequency <= 0:
+        raise ValueError(_ERROR_MAX_FREQUENCY)
+
+
+def encode_shm_raw_data(raw_data: RawData) -> bytes:
+    """Encode a ``RawData`` message for the bytes-only SHM transport."""
+    return cbor2.dumps(
+        {
+            _WIRE_VERSION: _WIRE_VERSION_VALUE,
+            _WIRE_CONTENT: raw_data.content,
+            _WIRE_CONTENT_TYPE: str(raw_data.content_type),
+        },
+    )
+
+
+def decode_shm_raw_data(payload: bytes) -> RawData:
+    """Decode a ``RawData`` message received through shared memory."""
+    wire_data = cbor2.loads(payload)
+    if not isinstance(wire_data, dict):
+        raise TypeError(_ERROR_PAYLOAD_NOT_MAPPING)
+    if wire_data.get(_WIRE_VERSION) != _WIRE_VERSION_VALUE:
+        raise ValueError(_ERROR_PAYLOAD_VERSION)
+
+    content = wire_data.get(_WIRE_CONTENT)
+    content_type = wire_data.get(_WIRE_CONTENT_TYPE)
+    if not isinstance(content, bytes):
+        raise TypeError(_ERROR_PAYLOAD_CONTENT)
+    if not isinstance(content_type, str):
+        raise TypeError(_ERROR_PAYLOAD_CONTENT_TYPE)
+    raw_content_type = ContentType(content_type)
+    return RawData(
+        content=content,
+        content_type=raw_content_type,
+    )
+
+
+class _ShmWriterEntry:
+    """Coordinate access to one reusable shared-memory writer."""
+
+    def __init__(self, writer: ShmWriter) -> None:
+        """Store a writer and its lifecycle lock."""
+        self.writer = writer
+        self.lock = Lock()
+        self.closed = False
+
+
+class ShmWriterPool:
+    """Manage reusable SHM writers with synchronized lifecycle."""
+
+    def __init__(self) -> None:
+        """Initialize an empty writer pool."""
+        self._lock = Lock()
+        self._writers: dict[str, _ShmWriterEntry] = {}
+        self._closed = False
+
+    def _get_writer_entry(self, shm_path: str) -> _ShmWriterEntry | None:
+        """Get or create the active entry for one channel."""
+        with self._lock:
+            if self._closed:
+                return None
+            writer_entry = self._writers.get(shm_path)
+            if writer_entry is not None:
+                return writer_entry
+            writer = ShmWriter(
+                shm_path,
+                logger.warning,
+                logger.error,
+            )
+            writer_entry = _ShmWriterEntry(writer)
+            self._writers[shm_path] = writer_entry
+            return writer_entry
+
+    def _discard_writer_entry_locked(
+        self,
+        shm_path: str,
+        writer_entry: _ShmWriterEntry,
+    ) -> None:
+        """Close a failed entry before detaching it from the pool."""
+        try:
+            writer_entry.writer.close()
+        finally:
+            with self._lock:
+                if self._writers.get(shm_path) is writer_entry:
+                    self._writers.pop(shm_path)
+
+    def _close_writer_entry(self, writer_entry: _ShmWriterEntry) -> None:
+        """Close an entry after its channel publish completes."""
+        with writer_entry.lock:
+            if writer_entry.closed:
+                return
+            writer_entry.closed = True
+            writer_entry.writer.close()
+
+    def publish(self, raw_data: RawData, shm_path: str) -> bool:
+        """Publish ``raw_data`` and report SHM delivery."""
+        cleanup_error: Exception | None = None
+        try:
+            encoded_raw_data = encode_shm_raw_data(raw_data)
+            writer_entry = self._get_writer_entry(shm_path)
+            if writer_entry is None:
+                return False
+            with writer_entry.lock:
+                if writer_entry.closed:
+                    return False
+                try:
+                    writer_entry.writer.publish(encoded_raw_data)
+                except Exception:
+                    writer_entry.closed = True
+                    try:
+                        self._discard_writer_entry_locked(
+                            shm_path,
+                            writer_entry,
+                        )
+                    except Exception as discard_error:  # noqa: BLE001
+                        cleanup_error = discard_error
+                    raise
+        except Exception as publish_error:  # noqa: BLE001
+            if cleanup_error is None:
+                logger.warning(
+                    "DTPS shared-memory publish to %r failed: %s; "
+                    "falling back to normal DTPS delivery.",
+                    shm_path,
+                    publish_error,
+                )
+            else:
+                logger.warning(
+                    "DTPS shared-memory publish to %r failed: %s; "
+                    "writer cleanup also failed: %s; falling back to normal "
+                    "DTPS delivery.",
+                    shm_path,
+                    publish_error,
+                    cleanup_error,
+                )
+            return False
+        return True
+
+    def close(self) -> None:
+        """Close all writers managed by this pool."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            writer_entry_values = self._writers.values()
+            writer_entries = list(writer_entry_values)
+            self._writers.clear()
+        for writer_entry in writer_entries:
+            self._close_writer_entry(writer_entry)
+
+
+def should_publish_http(
+    writer_pool: ShmWriterPool,
+    raw_data: RawData,
+    *,
+    shm_path: str | None,
+    shm_only: bool,
+) -> bool:
+    """Publish to SHM and indicate whether HTTP delivery is required."""
+    validate_shm_configuration(shm_path, shm_only=shm_only)
+    if not shm_path:
+        return True
+    shm_published = writer_pool.publish(raw_data, shm_path)
+    if not shm_only:
+        return True
+    return not shm_published
+
+
+class _ShmSubscription(SubscriptionInterface):
+    """Deliver an SHM channel through DTPS's async callback contract."""
+
+    def __init__(
+        self,
+        on_data: Callable[[RawData], Awaitable[None]],
+        shm_path: str,
+        queue_size: int,
+        *,
+        max_frequency: float | None = None,
+        on_unsubscribe: Callable[[SubscriptionInterface], None] | None = None,
+    ) -> None:
+        """Start a reader and processor for a single SHM channel."""
+        validate_max_frequency(max_frequency)
+        self._closed = False
+        self._loop = asyncio.get_running_loop()
+        self._on_data = on_data
+        self._on_unsubscribe = on_unsubscribe
+        self._when = EveryOnceInAWhile(
+            1 / max_frequency if max_frequency is not None else 0,
+        )
+        self._queue: asyncio.Queue[RawData] = asyncio.Queue(
+            maxsize=queue_size,
+        )
+        self._reader = ShmReader(
+            shm_path,
+            self._on_payload,
+            logger.warning,
+            logger.error,
+        )
+        self._reader.start()
+        processor = self._process()
+        try:
+            self._processor_task = self._loop.create_task(processor)
+        except Exception:
+            self._closed = True
+            processor.close()
+            self._reader.stop()
+            raise
+
+    def _on_payload(self, payload: bytes) -> None:
+        """Decode one SHM payload and transfer it to the event loop."""
+        try:
+            raw_data = decode_shm_raw_data(payload)
+        except Exception as error:  # noqa: BLE001
+            logger.warning(
+                "Ignoring invalid DTPS shared-memory payload: %s",
+                error,
+            )
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._enqueue, raw_data)
+        except RuntimeError:
+            # The loop can close while the reader callback is returning.
+            return
+
+    def _enqueue(self, raw_data: RawData) -> None:
+        """Keep only the latest pending callback payload."""
+        if self._closed or not self._when.now():
+            return
+        while True:
+            with suppress(asyncio.QueueFull):
+                self._queue.put_nowait(raw_data)
+                return
+            with suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+                self._queue.task_done()
+
+    async def _process(self) -> None:
+        """Run user callbacks in the subscribing event loop."""
+        while True:
+            raw_data = await self._queue.get()
+            try:
+                await self._on_data(raw_data)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Exception in DTPS shared-memory subscription callback.",
+                )
+            finally:
+                self._queue.task_done()
+            if self._closed:
+                return
+
+    async def unsubscribe(self) -> None:
+        """Stop the reader and cancel its callback processor."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._reader.stop()
+        finally:
+            processor_task = self._processor_task
+            if processor_task is not asyncio.current_task():
+                processor_task.cancel()
+                await asyncio.gather(
+                    processor_task,
+                    return_exceptions=True,
+                )
+            on_unsubscribe = self._on_unsubscribe
+            if on_unsubscribe is not None:
+                on_unsubscribe(self)
+
+
+def create_shm_subscription(
+    on_data: Callable[[RawData], Awaitable[None]],
+    shm_path: str,
+    queue_size: int,
+    *,
+    max_frequency: float | None = None,
+    on_unsubscribe: Callable[[SubscriptionInterface], None] | None = None,
+) -> SubscriptionInterface:
+    """Build a subscription that receives from ``shm_path``."""
+    return _ShmSubscription(
+        on_data,
+        shm_path,
+        queue_size,
+        max_frequency=max_frequency,
+        on_unsubscribe=on_unsubscribe,
+    )

--- a/src/dtps_http/constants.py
+++ b/src/dtps_http/constants.py
@@ -1,4 +1,5 @@
 import os
+import struct
 
 from .types import ContentType, TopicNameV
 
@@ -43,6 +44,55 @@ __all__ = [
     "REL_STREAM_PUSH_SUFFIX",
     "REL_URL_HISTORY",
     "REL_URL_META",
+    "SHM_CHANNEL_DIRECTORY_MODE",
+    "SHM_CHANNEL_FILE_MODE",
+    "SHM_DEFAULT_CAPACITY",
+    "SHM_ERROR_CAPACITY",
+    "SHM_ERROR_CAPACITY_EXCEEDS_MAXIMUM",
+    "SHM_ERROR_CHANNEL_DIRECTORY_NOT_DIRECTORY",
+    "SHM_ERROR_CHANNEL_DIRECTORY_NOT_OWNER",
+    "SHM_ERROR_CHANNEL_DIRECTORY_SYMLINK",
+    "SHM_ERROR_CHANNEL_DIRECTORY_WORLD_WRITABLE",
+    "SHM_ERROR_CHANNEL_PATH_HAS_MULTIPLE_LINKS",
+    "SHM_ERROR_CHANNEL_PATH_NOT_REGULAR_FILE",
+    "SHM_ERROR_CLOSE_LOCK_FILE",
+    "SHM_ERROR_CLOSE_MAP",
+    "SHM_ERROR_CLOSE_SIGNAL_FIFO",
+    "SHM_ERROR_HANDLE_PAYLOAD",
+    "SHM_ERROR_HEADER_MAGIC",
+    "SHM_ERROR_HEADER_SIZE",
+    "SHM_ERROR_HEADER_UNPACK",
+    "SHM_ERROR_PAYLOAD_LENGTH",
+    "SHM_ERROR_READ_PAYLOAD",
+    "SHM_ERROR_READER_LOCK_NOT_OPEN",
+    "SHM_ERROR_READER_NOT_OPEN",
+    "SHM_ERROR_READER_REMAP_FAILED",
+    "SHM_ERROR_READER_STOPPING",
+    "SHM_ERROR_SIGNAL_FIFO_ACCESSIBLE_BY_OTHERS",
+    "SHM_ERROR_SIGNAL_FIFO_NOT_OWNER",
+    "SHM_ERROR_SIGNAL_PATH_NOT_FIFO",
+    "SHM_ERROR_SIGNAL_POLL_FAILED",
+    "SHM_ERROR_SIGNAL_READ_FAILED",
+    "SHM_ERROR_UNSUPPORTED_VERSION",
+    "SHM_ERROR_UNSUPPORTED_PLATFORM",
+    "SHM_ERROR_WRITER_LOCK_NOT_OPEN",
+    "SHM_ERROR_WRITER_MAP_NOT_OPEN",
+    "SHM_ERROR_WRITER_NOT_OPEN",
+    "SHM_FIFO_FULL_WARNING",
+    "SHM_HEADER_FORMAT",
+    "SHM_HEADER_SIZE",
+    "SHM_LOCK_SUFFIX",
+    "SHM_MAGIC",
+    "SHM_MAX_CAPACITY",
+    "SHM_SIGNAL_DRAIN_READS",
+    "SHM_SIGNAL_DRAIN_READ_SIZE",
+    "SHM_SIGNAL_FORMAT",
+    "SHM_SIGNAL_POLL_TIMEOUT_SECONDS",
+    "SHM_SIGNAL_SUFFIX",
+    "SHM_STOP_JOIN_TIMEOUT_SECONDS",
+    "SHM_VERSION",
+    "SHM_WARNING_READER_STILL_STOPPING",
+    "SHM_WARNING_RESET_HEADER",
     "TOPIC_AVAILABILITY",
     "TOPIC_CLOCK",
     "TOPIC_CONNECTIONS",
@@ -115,3 +165,77 @@ DEFAULT_MAX_HISTORY: int = 10
 DEFAULT_DATA_AVAILABILITY_TIMEOUT: float = float(os.environ.get("DTPS_DATA_AVAILABILITY_TIMEOUT", "60"))
 
 DEFAULT_CALLBACK_QUEUE_SIZE: int = 10
+
+SHM_CHANNEL_DIRECTORY_MODE = 0o700
+SHM_CHANNEL_FILE_MODE = 0o600
+SHM_DEFAULT_CAPACITY = 1024 * 1024
+SHM_MAX_CAPACITY = 64 * 1024 * 1024
+SHM_HEADER_FORMAT = "<4sIII"
+SHM_HEADER_SIZE = struct.calcsize(SHM_HEADER_FORMAT)
+SHM_LOCK_SUFFIX = ".lock"
+SHM_MAGIC = b"DTCM"
+SHM_SIGNAL_FORMAT = "<Q"
+SHM_SIGNAL_DRAIN_READ_SIZE = 4096
+SHM_SIGNAL_DRAIN_READS = 16
+SHM_SIGNAL_SUFFIX = ".p2c"
+SHM_SIGNAL_POLL_TIMEOUT_SECONDS = 0.1
+SHM_STOP_JOIN_TIMEOUT_SECONDS = 1
+SHM_VERSION = 1
+
+SHM_ERROR_HEADER_SIZE = "Shared-memory header has an unexpected size."
+SHM_ERROR_HEADER_UNPACK = "Shared-memory header could not be unpacked."
+SHM_ERROR_HEADER_MAGIC = "Unexpected shared-memory magic."
+SHM_ERROR_UNSUPPORTED_VERSION = "Unsupported shared-memory version"
+SHM_ERROR_UNSUPPORTED_PLATFORM = (
+    "Shared-memory transport requires POSIX platform capabilities"
+)
+SHM_ERROR_CAPACITY = "Shared-memory capacity must be positive."
+SHM_ERROR_CAPACITY_EXCEEDS_MAXIMUM = (
+    "Shared-memory capacity exceeds configured maximum"
+)
+SHM_ERROR_CHANNEL_DIRECTORY_NOT_DIRECTORY = (
+    "Shared-memory channel directory is not a directory"
+)
+SHM_ERROR_CHANNEL_DIRECTORY_NOT_OWNER = (
+    "Shared-memory channel directory is not owned by the current user or root"
+)
+SHM_ERROR_CHANNEL_DIRECTORY_SYMLINK = (
+    "Shared-memory channel directory is a symlink"
+)
+SHM_ERROR_CHANNEL_DIRECTORY_WORLD_WRITABLE = (
+    "Shared-memory channel directory is writable by other users"
+)
+SHM_ERROR_CHANNEL_PATH_HAS_MULTIPLE_LINKS = (
+    "Shared-memory channel path has multiple hard links"
+)
+SHM_ERROR_CHANNEL_PATH_NOT_REGULAR_FILE = (
+    "Shared-memory channel path is not a regular file"
+)
+SHM_ERROR_CLOSE_LOCK_FILE = "Failed to close shared-memory lock file"
+SHM_ERROR_CLOSE_MAP = "Failed to close shared-memory map"
+SHM_ERROR_CLOSE_SIGNAL_FIFO = "Failed to close shared-memory signal FIFO"
+SHM_ERROR_HANDLE_PAYLOAD = "Failed to handle shared-memory payload"
+SHM_ERROR_PAYLOAD_LENGTH = "Shared-memory payload length exceeds configured capacity."
+SHM_ERROR_READ_PAYLOAD = "Failed to read shared-memory payload"
+SHM_ERROR_READER_LOCK_NOT_OPEN = "Shared-memory reader lock is not open."
+SHM_ERROR_READER_NOT_OPEN = "Shared-memory reader is not open."
+SHM_ERROR_READER_REMAP_FAILED = "Shared-memory reader remap failed."
+SHM_ERROR_READER_STOPPING = "Shared-memory reader is still stopping."
+SHM_ERROR_SIGNAL_FIFO_ACCESSIBLE_BY_OTHERS = (
+    "Shared-memory signal FIFO is accessible by other users"
+)
+SHM_ERROR_SIGNAL_FIFO_NOT_OWNER = (
+    "Shared-memory signal FIFO is not owned by the current user or root"
+)
+SHM_ERROR_SIGNAL_PATH_NOT_FIFO = "Shared-memory signal path is not a FIFO"
+SHM_ERROR_SIGNAL_POLL_FAILED = "Shared-memory signal poll failed"
+SHM_ERROR_SIGNAL_READ_FAILED = "Shared-memory signal read failed"
+SHM_ERROR_WRITER_LOCK_NOT_OPEN = "Shared-memory writer lock is not open."
+SHM_ERROR_WRITER_MAP_NOT_OPEN = "Shared-memory writer map is not open."
+SHM_ERROR_WRITER_NOT_OPEN = "Shared-memory writer is not open."
+SHM_FIFO_FULL_WARNING = "Shared-memory signal FIFO is full; coalescing wake-ups."
+SHM_WARNING_READER_STILL_STOPPING = (
+    "Shared-memory reader is still stopping; "
+    "resources will close after its callback returns."
+)
+SHM_WARNING_RESET_HEADER = "Resetting shared-memory header at"

--- a/src/dtps_http/shm.py
+++ b/src/dtps_http/shm.py
@@ -1,0 +1,1005 @@
+"""Latest-value shared-memory transport for one producer and one reader.
+
+The channel stores opaque bytes in a memory-mapped file. A ``.p2c`` FIFO
+notifies the reader after each write. Its header carries capacity and
+current payload length. Zero length marks an update in progress.
+
+A ``.lock`` file serializes shared-memory state. Writers hold exclusive
+locks while initializing, resizing, or replacing payloads. Readers hold
+shared locks while remapping and copying. This prevents overwrites while
+another endpoint copies bytes.
+
+This latest-frame transport is not a reliable queue. Writers can replace
+unread data. FIFO notifications can be dropped after newer data arrives.
+Consumers must tolerate drops or repeats. Payloads stay coherent for
+cooperating endpoints.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import select
+import stat
+import struct
+import time
+from contextlib import contextmanager, suppress
+from importlib import import_module
+from mmap import mmap
+from pathlib import Path
+from threading import Thread, current_thread
+from typing import Any, Callable, Iterator
+
+from .constants import (
+    SHM_CHANNEL_DIRECTORY_MODE,
+    SHM_CHANNEL_FILE_MODE,
+    SHM_DEFAULT_CAPACITY,
+    SHM_ERROR_CAPACITY,
+    SHM_ERROR_CAPACITY_EXCEEDS_MAXIMUM,
+    SHM_ERROR_CHANNEL_DIRECTORY_NOT_DIRECTORY,
+    SHM_ERROR_CHANNEL_DIRECTORY_NOT_OWNER,
+    SHM_ERROR_CHANNEL_DIRECTORY_SYMLINK,
+    SHM_ERROR_CHANNEL_DIRECTORY_WORLD_WRITABLE,
+    SHM_ERROR_CHANNEL_PATH_HAS_MULTIPLE_LINKS,
+    SHM_ERROR_CHANNEL_PATH_NOT_REGULAR_FILE,
+    SHM_ERROR_CLOSE_LOCK_FILE,
+    SHM_ERROR_CLOSE_MAP,
+    SHM_ERROR_CLOSE_SIGNAL_FIFO,
+    SHM_ERROR_HANDLE_PAYLOAD,
+    SHM_ERROR_HEADER_MAGIC,
+    SHM_ERROR_HEADER_SIZE,
+    SHM_ERROR_HEADER_UNPACK,
+    SHM_ERROR_PAYLOAD_LENGTH,
+    SHM_ERROR_READ_PAYLOAD,
+    SHM_ERROR_READER_LOCK_NOT_OPEN,
+    SHM_ERROR_READER_NOT_OPEN,
+    SHM_ERROR_READER_REMAP_FAILED,
+    SHM_ERROR_READER_STOPPING,
+    SHM_ERROR_SIGNAL_FIFO_ACCESSIBLE_BY_OTHERS,
+    SHM_ERROR_SIGNAL_FIFO_NOT_OWNER,
+    SHM_ERROR_SIGNAL_PATH_NOT_FIFO,
+    SHM_ERROR_SIGNAL_POLL_FAILED,
+    SHM_ERROR_SIGNAL_READ_FAILED,
+    SHM_ERROR_UNSUPPORTED_PLATFORM,
+    SHM_ERROR_UNSUPPORTED_VERSION,
+    SHM_ERROR_WRITER_LOCK_NOT_OPEN,
+    SHM_ERROR_WRITER_MAP_NOT_OPEN,
+    SHM_ERROR_WRITER_NOT_OPEN,
+    SHM_FIFO_FULL_WARNING,
+    SHM_HEADER_FORMAT,
+    SHM_HEADER_SIZE,
+    SHM_LOCK_SUFFIX,
+    SHM_MAGIC,
+    SHM_MAX_CAPACITY,
+    SHM_SIGNAL_DRAIN_READ_SIZE,
+    SHM_SIGNAL_DRAIN_READS,
+    SHM_SIGNAL_FORMAT,
+    SHM_SIGNAL_POLL_TIMEOUT_SECONDS,
+    SHM_SIGNAL_SUFFIX,
+    SHM_STOP_JOIN_TIMEOUT_SECONDS,
+    SHM_VERSION,
+    SHM_WARNING_READER_STILL_STOPPING,
+    SHM_WARNING_RESET_HEADER,
+)
+
+fcntl: Any = None
+with suppress(ModuleNotFoundError):
+    fcntl = import_module("fcntl")
+
+_REQUIRED_FCNTL_CAPABILITIES = (
+    "flock",
+    "LOCK_EX",
+    "LOCK_SH",
+    "LOCK_UN",
+)
+_REQUIRED_OS_CAPABILITIES = (
+    "O_CLOEXEC",
+    "O_NOFOLLOW",
+    "O_NONBLOCK",
+    "chmod",
+    "fchmod",
+    "ftruncate",
+    "geteuid",
+    "mkfifo",
+    "pread",
+    "pwrite",
+)
+
+
+def _ensure_supported_platform() -> None:
+    """Reject unsupported platform capability sets."""
+    missing_capabilities: list[str] = []
+    if os.name != "posix":
+        missing_capabilities.append("POSIX")
+
+    fcntl_module = fcntl
+    if fcntl_module is None:
+        missing_capabilities.append("fcntl")
+    else:
+        missing_fcntl_capabilities = [
+            f"fcntl.{capability}"
+            for capability in _REQUIRED_FCNTL_CAPABILITIES
+            if getattr(fcntl_module, capability, None) is None
+        ]
+        missing_capabilities.extend(missing_fcntl_capabilities)
+
+    missing_os_capabilities = [
+        f"os.{capability}"
+        for capability in _REQUIRED_OS_CAPABILITIES
+        if getattr(os, capability, None) is None
+    ]
+    missing_capabilities.extend(missing_os_capabilities)
+
+    if missing_capabilities:
+        message = (
+            f"{SHM_ERROR_UNSUPPORTED_PLATFORM}: "
+            f"{', '.join(missing_capabilities)}."
+        )
+        raise OSError(message)
+
+
+def _validate_capacity(capacity: int) -> None:
+    """Reject channel capacities outside the supported range."""
+    if capacity <= 0:
+        raise ValueError(SHM_ERROR_CAPACITY)
+    if capacity <= SHM_MAX_CAPACITY:
+        return
+    message = (
+        f"{SHM_ERROR_CAPACITY_EXCEEDS_MAXIMUM}: "
+        f"{capacity} > {SHM_MAX_CAPACITY}."
+    )
+    raise ValueError(message)
+
+
+def _pack_header(capacity: int, payload_length: int) -> bytes:
+    """Return the on-disk header for the current buffer state."""
+    _validate_capacity(capacity)
+    return struct.pack(
+        SHM_HEADER_FORMAT,
+        SHM_MAGIC,
+        SHM_VERSION,
+        capacity,
+        payload_length,
+    )
+
+
+@contextmanager
+def _channel_lock(
+    lock_file_descriptor: int,
+    lock_mode: int,
+) -> Iterator[None]:
+    """Hold a cooperative process-shared lock for one operation."""
+    fcntl.flock(lock_file_descriptor, lock_mode)
+    try:
+        yield
+    finally:
+        fcntl.flock(lock_file_descriptor, fcntl.LOCK_UN)
+
+
+def _validate_channel_directory(
+    channel_directory: Path,
+    directory_status: os.stat_result,
+    *,
+    allow_sticky_writable_directory: bool = False,
+) -> None:
+    """Reject unsafe channel directories."""
+    directory_name = str(channel_directory)
+    if stat.S_ISLNK(directory_status.st_mode):
+        message = f"{SHM_ERROR_CHANNEL_DIRECTORY_SYMLINK}: '{directory_name}'"
+        raise ValueError(message)
+    if not stat.S_ISDIR(directory_status.st_mode):
+        message = (
+            f"{SHM_ERROR_CHANNEL_DIRECTORY_NOT_DIRECTORY}: '{directory_name}'"
+        )
+        raise ValueError(message)
+    if directory_status.st_uid not in (0, os.geteuid()):
+        message = (
+            f"{SHM_ERROR_CHANNEL_DIRECTORY_NOT_OWNER}: '{directory_name}'"
+        )
+        raise ValueError(message)
+    if directory_status.st_mode & (stat.S_IWGRP | stat.S_IWOTH) and not (
+        allow_sticky_writable_directory
+        and directory_status.st_mode & stat.S_ISVTX
+    ):
+        message = (
+            f"{SHM_ERROR_CHANNEL_DIRECTORY_WORLD_WRITABLE}: '{directory_name}'"
+        )
+        raise ValueError(message)
+
+
+def _channel_directory_components(
+    channel_directory: Path,
+) -> list[Path]:
+    """Return the channel directory components from shallow to deep."""
+    directory_components = [channel_directory]
+    directory_components.extend(channel_directory.parents)
+    directory_components.reverse()
+    return directory_components
+
+
+def _ensure_channel_directory(channel_path: str) -> None:
+    """Create and validate a channel artifact directory."""
+    channel_file_path = Path(channel_path)
+    channel_directory = channel_file_path.parent
+    directory_components = _channel_directory_components(channel_directory)
+    for directory_component in directory_components:
+        is_channel_directory = directory_component == channel_directory
+        try:
+            directory_component.mkdir(mode=SHM_CHANNEL_DIRECTORY_MODE)
+        except FileExistsError:
+            directory_status = os.lstat(directory_component)
+        else:
+            directory_component.chmod(SHM_CHANNEL_DIRECTORY_MODE)
+            directory_status = os.lstat(directory_component)
+        _validate_channel_directory(
+            directory_component,
+            directory_status,
+            allow_sticky_writable_directory=not is_channel_directory,
+        )
+
+
+def _ensure_signal_fifo(
+    signal_path: str,
+) -> tuple[bool, tuple[int, int] | None]:
+    """Create a FIFO or reject a conflicting existing path."""
+    try:
+        os.mkfifo(signal_path, SHM_CHANNEL_FILE_MODE)
+    except FileExistsError:
+        signal_status = os.lstat(signal_path)
+        _validate_signal_fifo_status(signal_status, signal_path)
+        return False, None
+    signal_status = os.lstat(signal_path)
+    signal_identity = (signal_status.st_dev, signal_status.st_ino)
+    try:
+        _validate_signal_fifo_status(signal_status, signal_path)
+        signal_file_path = Path(signal_path)
+        signal_file_path.chmod(SHM_CHANNEL_FILE_MODE)
+        signal_status = os.lstat(signal_path)
+        _validate_signal_fifo_status(signal_status, signal_path)
+    except Exception:
+        with suppress(OSError):
+            _unlink_signal_fifo_if_unchanged(
+                signal_path,
+                signal_identity,
+            )
+        raise
+    return True, signal_identity
+
+
+def _unlink_signal_fifo_if_unchanged(
+    signal_path: str,
+    expected_identity: tuple[int, int],
+) -> None:
+    """Remove a newly created FIFO only when its path still names it."""
+    try:
+        signal_status = os.lstat(signal_path)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISFIFO(signal_status.st_mode):
+        return
+    if (signal_status.st_dev, signal_status.st_ino) != expected_identity:
+        return
+    signal_file_path = Path(signal_path)
+    signal_file_path.unlink()
+
+
+def _validate_signal_file_descriptor(
+    signal_file_descriptor: int,
+    signal_path: str,
+) -> None:
+    """Verify a signal descriptor meets the private FIFO contract."""
+    signal_status = os.fstat(signal_file_descriptor)
+    _validate_signal_fifo_status(signal_status, signal_path)
+
+
+def _validate_signal_fifo_status(
+    signal_status: os.stat_result,
+    signal_path: str,
+) -> None:
+    """Verify a signal path status meets the private FIFO contract."""
+    if stat.S_ISFIFO(signal_status.st_mode):
+        if signal_status.st_uid not in (0, os.geteuid()):
+            message = f"{SHM_ERROR_SIGNAL_FIFO_NOT_OWNER}: '{signal_path}'"
+            raise ValueError(message)
+        if signal_status.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
+            message = (
+                f"{SHM_ERROR_SIGNAL_FIFO_ACCESSIBLE_BY_OTHERS}: "
+                f"'{signal_path}'"
+            )
+            raise ValueError(message)
+        return
+    message = f"{SHM_ERROR_SIGNAL_PATH_NOT_FIFO}: '{signal_path}'"
+    raise ValueError(message)
+
+
+def _open_signal_fifo(signal_path: str, *, created: bool) -> int:
+    """Open a signal FIFO without following a symlink substitution."""
+    signal_file_descriptor = os.open(
+        signal_path,
+        os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
+    )
+    try:
+        _validate_signal_file_descriptor(signal_file_descriptor, signal_path)
+        if created:
+            os.fchmod(signal_file_descriptor, SHM_CHANNEL_FILE_MODE)
+    except Exception:
+        os.close(signal_file_descriptor)
+        raise
+    return signal_file_descriptor
+
+
+def _open_or_create_channel_file(
+    channel_path: str,
+    open_flags: int,
+    mode: int,
+) -> tuple[int, bool]:
+    """Open a channel file and report whether this call created it."""
+    try:
+        file_descriptor = os.open(
+            channel_path,
+            open_flags | os.O_EXCL,
+            mode,
+        )
+    except FileExistsError:
+        file_descriptor = os.open(
+            channel_path,
+            open_flags & ~(os.O_CREAT | os.O_EXCL),
+        )
+        return file_descriptor, False
+    return file_descriptor, True
+
+
+def _open_channel_file_descriptor(
+    channel_path: str,
+    flags: int,
+    mode: int | None,
+) -> tuple[int, bool]:
+    """Open a channel descriptor and report whether it was created."""
+    open_flags = flags | os.O_CLOEXEC | os.O_NOFOLLOW
+    if mode is None:
+        return os.open(channel_path, open_flags), False
+    if flags & os.O_CREAT:
+        return _open_or_create_channel_file(channel_path, open_flags, mode)
+    return os.open(channel_path, open_flags, mode), False
+
+
+def _raise_channel_path_not_regular(
+    channel_path: str,
+    error: OSError | None = None,
+) -> None:
+    """Raise the unsafe artifact-path error."""
+    message = f"{SHM_ERROR_CHANNEL_PATH_NOT_REGULAR_FILE}: '{channel_path}'"
+    if error is None:
+        raise ValueError(message)
+    raise ValueError(message) from error
+
+
+def _validate_channel_file_descriptor(
+    file_descriptor: int,
+    channel_path: str,
+) -> None:
+    """Verify that a channel descriptor is singly linked."""
+    file_status = os.fstat(file_descriptor)
+    if not stat.S_ISREG(file_status.st_mode):
+        _raise_channel_path_not_regular(channel_path)
+    if file_status.st_nlink == 1:
+        return
+    message = (
+        f"{SHM_ERROR_CHANNEL_PATH_HAS_MULTIPLE_LINKS}: '{channel_path}'"
+    )
+    raise ValueError(message)
+
+
+def _open_channel_file(
+    channel_path: str,
+    flags: int,
+    mode: int | None = None,
+) -> int:
+    """Open an unlinked regular artifact without following symlinks."""
+    try:
+        file_descriptor, created = _open_channel_file_descriptor(
+            channel_path,
+            flags,
+            mode,
+        )
+    except OSError as error:
+        if error.errno == errno.ELOOP:
+            _raise_channel_path_not_regular(channel_path, error)
+        raise
+
+    try:
+        _validate_channel_file_descriptor(file_descriptor, channel_path)
+        if created and mode is not None:
+            os.fchmod(file_descriptor, mode)
+    except Exception:
+        os.close(file_descriptor)
+        raise
+    return file_descriptor
+
+
+def _unpack_header(header: bytes) -> tuple[int, int]:
+    """Validate a header and return capacity and payload length."""
+    if len(header) != SHM_HEADER_SIZE:
+        raise ValueError(SHM_ERROR_HEADER_SIZE)
+    try:
+        magic, version, capacity, payload_length = struct.unpack(
+            SHM_HEADER_FORMAT,
+            header,
+        )
+    except struct.error as error:
+        raise ValueError(SHM_ERROR_HEADER_UNPACK) from error
+    if magic != SHM_MAGIC:
+        raise ValueError(SHM_ERROR_HEADER_MAGIC)
+    if version != SHM_VERSION:
+        message = f"{SHM_ERROR_UNSUPPORTED_VERSION}: {version}"
+        raise ValueError(message)
+    _validate_capacity(capacity)
+    if payload_length > capacity:
+        raise ValueError(SHM_ERROR_PAYLOAD_LENGTH)
+    return capacity, payload_length
+
+
+class _ShmEndpoint:
+    """Manage resources shared by a shared-memory reader or writer."""
+
+    def __init__(
+        self,
+        shm_path: str,
+        logwarn: Callable[[str], None],
+        logerr: Callable[[str], None],
+        lock_not_open_message: str,
+    ) -> None:
+        """Initialize shared endpoint resources."""
+        _ensure_supported_platform()
+        self._capacity = SHM_DEFAULT_CAPACITY
+        self._logerr = logerr
+        self._logwarn = logwarn
+        self._lock_not_open_message = lock_not_open_message
+        self._shm_path = str(shm_path)
+        self._lock_file_descriptor: int | None = None
+        self._lock_path = self._shm_path + SHM_LOCK_SUFFIX
+        self._map_size = SHM_HEADER_SIZE + self._capacity
+        self._memory_map: mmap | None = None
+        self._signal_file_descriptor: int | None = None
+        self._signal_path = self._shm_path + SHM_SIGNAL_SUFFIX
+
+    def _close_handles(self) -> None:
+        """Release the mapping, FIFO descriptor, and lock file."""
+        memory_map = self._memory_map
+        self._memory_map = None
+        try:
+            if memory_map is not None:
+                memory_map.close()
+        except Exception as error:  # noqa: BLE001
+            message = f"{SHM_ERROR_CLOSE_MAP}: {error}"
+            self._logerr(message)
+
+        signal_file_descriptor = self._signal_file_descriptor
+        self._signal_file_descriptor = None
+        try:
+            if signal_file_descriptor is not None:
+                os.close(signal_file_descriptor)
+        except OSError as error:
+            message = f"{SHM_ERROR_CLOSE_SIGNAL_FIFO}: {error}"
+            self._logerr(message)
+
+        lock_file_descriptor = self._lock_file_descriptor
+        self._lock_file_descriptor = None
+        try:
+            if lock_file_descriptor is not None:
+                os.close(lock_file_descriptor)
+        except OSError as error:
+            message = f"{SHM_ERROR_CLOSE_LOCK_FILE}: {error}"
+            self._logerr(message)
+
+    def _ensure_lock_open(self) -> None:
+        """Open the dedicated advisory lock file for this channel."""
+        if self._lock_file_descriptor is not None:
+            return
+        _ensure_channel_directory(self._shm_path)
+        # Use a separate inode so locks survive backing-file resizing.
+        self._lock_file_descriptor = _open_channel_file(
+            self._lock_path,
+            os.O_CREAT | os.O_RDWR,
+            SHM_CHANNEL_FILE_MODE,
+        )
+
+    def _ensure_open(self) -> None:
+        """Create and map the channel for this endpoint."""
+        if (
+            self._lock_file_descriptor is not None
+            and self._memory_map is not None
+            and self._signal_file_descriptor is not None
+        ):
+            return
+        self._ensure_lock_open()
+        lock_file_descriptor = self._lock_file_descriptor
+        if lock_file_descriptor is None:
+            raise RuntimeError(self._lock_not_open_message)
+
+        # Initialization can reset shared state. Use one exclusive lock
+        # for both endpoints.
+        try:
+            with _channel_lock(lock_file_descriptor, fcntl.LOCK_EX):
+                self._open_channel_locked()
+        except Exception:
+            self._close_handles()
+            raise
+
+    def _open_channel_locked(self) -> None:
+        """Prepare, map, and open the channel while holding its lock."""
+        signal_created = False
+        signal_identity: tuple[int, int] | None = None
+        try:
+            self._prepare_channel_locked()
+            signal_created, signal_identity = _ensure_signal_fifo(
+                self._signal_path,
+            )
+            self._memory_map = self._open_memory_map(self._map_size)
+            self._signal_file_descriptor = _open_signal_fifo(
+                self._signal_path,
+                created=signal_created,
+            )
+        except Exception:
+            if signal_created and signal_identity is not None:
+                self._remove_created_signal_fifo(signal_identity)
+            raise
+
+    def _remove_created_signal_fifo(
+        self,
+        signal_identity: tuple[int, int],
+    ) -> None:
+        """Best-effort cleanup for the FIFO created by this endpoint."""
+        try:
+            _unlink_signal_fifo_if_unchanged(
+                self._signal_path,
+                signal_identity,
+            )
+        except OSError as error:
+            message = (
+                "Unable to remove newly created shared-memory signal FIFO "
+                f"'{self._signal_path}': {error}"
+            )
+            self._logerr(message)
+
+    def _open_memory_map(self, size: int) -> mmap:
+        """Map *size* bytes without retaining a file descriptor."""
+        file_descriptor = _open_channel_file(self._shm_path, os.O_RDWR)
+        try:
+            return mmap(file_descriptor, size)
+        finally:
+            # The mapping remains valid after this descriptor closes.
+            os.close(file_descriptor)
+
+    def _reset_channel_locked(
+        self,
+        file_descriptor: int,
+        capacity: int,
+    ) -> None:
+        """Reset the channel to an empty buffer while holding a lock."""
+        self._capacity = capacity
+        self._map_size = SHM_HEADER_SIZE + self._capacity
+        empty_header = _pack_header(self._capacity, 0)
+        os.ftruncate(file_descriptor, self._map_size)
+        os.pwrite(file_descriptor, empty_header, 0)
+
+    def _prepare_channel_locked(self) -> None:
+        """Create or recover the channel under an exclusive lock."""
+        file_descriptor = _open_channel_file(
+            self._shm_path,
+            os.O_CREAT | os.O_RDWR,
+            SHM_CHANNEL_FILE_MODE,
+        )
+        try:
+            file_status = os.fstat(file_descriptor)
+            file_size = file_status.st_size
+            if file_size < SHM_HEADER_SIZE:
+                # A new or truncated file has no valid channel state.
+                self._reset_channel_locked(
+                    file_descriptor,
+                    SHM_DEFAULT_CAPACITY,
+                )
+                return
+
+            header = os.pread(file_descriptor, SHM_HEADER_SIZE, 0)
+            try:
+                self._capacity, _ = _unpack_header(header)
+            except ValueError as error:
+                # A corrupt or incompatible header cannot be reused.
+                message = (
+                    f"{SHM_WARNING_RESET_HEADER} '{self._shm_path}': {error}"
+                )
+                self._logwarn(message)
+                self._reset_channel_locked(
+                    file_descriptor,
+                    SHM_DEFAULT_CAPACITY,
+                )
+                return
+
+            self._map_size = SHM_HEADER_SIZE + self._capacity
+            if file_size < self._map_size:
+                # Preserve a valid header while extending the partially
+                # created backing file to its advertised capacity.
+                os.ftruncate(file_descriptor, self._map_size)
+        finally:
+            os.close(file_descriptor)
+
+
+class ShmWriter(_ShmEndpoint):
+    """Publish the most recent payload from a single producer.
+
+    Each call replaces current payload. It can briefly wait for readers
+    to finish coherent copies, but has no per-frame delivery guarantee.
+    """
+
+    def __init__(
+        self,
+        shm_path: str,
+        logwarn: Callable[[str], None],
+        logerr: Callable[[str], None],
+    ) -> None:
+        """Initialize the writer endpoint."""
+        super().__init__(
+            shm_path,
+            logwarn,
+            logerr,
+            SHM_ERROR_WRITER_LOCK_NOT_OPEN,
+        )
+        self._signal_backpressure_warned = False
+
+    def _resize_locked(self, min_capacity: int) -> None:
+        """Grow the backing buffer while holding the exclusive lock."""
+        _validate_capacity(min_capacity)
+        new_capacity = max(self._capacity * 2, min_capacity)
+        new_capacity = min(new_capacity, SHM_MAX_CAPACITY)
+        if self._memory_map is not None:
+            self._memory_map.close()
+            self._memory_map = None
+
+        file_descriptor = _open_channel_file(self._shm_path, os.O_RDWR)
+        try:
+            empty_header = _pack_header(new_capacity, 0)
+            os.ftruncate(file_descriptor, SHM_HEADER_SIZE + new_capacity)
+            # Readers treat this as empty until they remap.
+            # The next map uses the new capacity.
+            os.pwrite(file_descriptor, empty_header, 0)
+        finally:
+            os.close(file_descriptor)
+
+        self._capacity = new_capacity
+        self._map_size = SHM_HEADER_SIZE + self._capacity
+        self._memory_map = self._open_memory_map(self._map_size)
+
+    def _write_payload_locked(
+        self,
+        payload: bytes,
+        payload_length: int,
+    ) -> None:
+        """Write a payload while holding the exclusive channel lock."""
+        if payload_length > self._capacity:
+            self._resize_locked(payload_length)
+
+        memory_map_ = self._memory_map
+        if memory_map_ is None:
+            raise RuntimeError(SHM_ERROR_WRITER_MAP_NOT_OPEN)
+
+        # The exclusive lock prevents readers from copying during a
+        # replacement. Zero length protects non-cooperating readers.
+        memory_map_[:SHM_HEADER_SIZE] = _pack_header(self._capacity, 0)
+        memory_map_[SHM_HEADER_SIZE : SHM_HEADER_SIZE + payload_length] = (
+            payload
+        )
+        memory_map_[:SHM_HEADER_SIZE] = _pack_header(
+            self._capacity,
+            payload_length,
+        )
+
+    def _signal_reader(self, signal_file_descriptor: int) -> None:
+        """Send a FIFO wake-up after committing a payload."""
+        # The timestamp identifies a wake-up event only.
+        # The reader takes the latest mapped payload snapshot.
+        signal_timestamp = time.perf_counter_ns()
+        signal = struct.pack(SHM_SIGNAL_FORMAT, signal_timestamp)
+        try:
+            os.write(signal_file_descriptor, signal)
+            self._signal_backpressure_warned = False
+        except BlockingIOError:
+            # A queued token wakes the reader after it catches up.
+            # Dropping a token preserves latest-frame semantics.
+            if not self._signal_backpressure_warned:
+                self._logwarn(SHM_FIFO_FULL_WARNING)
+                self._signal_backpressure_warned = True
+
+    def publish(self, payload: bytes) -> None:
+        """Replace the current payload and signal a new snapshot."""
+        payload_length = len(payload)
+        if payload_length == 0:
+            return
+        self._ensure_open()
+        signal_file_descriptor = self._signal_file_descriptor
+        lock_file_descriptor = self._lock_file_descriptor
+        if signal_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_WRITER_NOT_OPEN)
+        if lock_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_WRITER_NOT_OPEN)
+
+        try:
+            with _channel_lock(lock_file_descriptor, fcntl.LOCK_EX):
+                self._write_payload_locked(payload, payload_length)
+            self._signal_reader(signal_file_descriptor)
+        except Exception:
+            self._close_handles()
+            raise
+
+    def clear(self) -> None:
+        """Clear the current payload without publishing a wake-up."""
+        self._ensure_open()
+        lock_file_descriptor = self._lock_file_descriptor
+        if lock_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_WRITER_LOCK_NOT_OPEN)
+
+        with _channel_lock(lock_file_descriptor, fcntl.LOCK_EX):
+            memory_map_ = self._memory_map
+            if memory_map_ is None:
+                raise RuntimeError(SHM_ERROR_WRITER_MAP_NOT_OPEN)
+            memory_map_[:SHM_HEADER_SIZE] = _pack_header(self._capacity, 0)
+
+    def close(self) -> None:
+        """Release this writer's map, FIFO descriptor, and lock file."""
+        self._close_handles()
+
+
+class ShmReader(_ShmEndpoint):
+    """Deliver best-effort latest payloads from a worker thread.
+
+    FIFO signals are wake-ups rather than frame ownership transfers. The
+    callback receives only the latest payload. It runs in a worker
+    thread and must be safe there.
+    """
+
+    def __init__(
+        self,
+        shm_path: str,
+        on_payload: Callable[[bytes], None],
+        logwarn: Callable[[str], None],
+        logerr: Callable[[str], None],
+    ) -> None:
+        """Initialize the reader endpoint and its callback."""
+        super().__init__(
+            shm_path,
+            logwarn,
+            logerr,
+            SHM_ERROR_READER_LOCK_NOT_OPEN,
+        )
+        self._on_payload = on_payload
+        self._running = False
+        self._thread = self._create_reader_thread()
+
+    def _create_reader_thread(self) -> Thread:
+        """Create the worker thread for one start-stop cycle."""
+        return Thread(
+            target=self._reader_loop,
+            daemon=True,
+            name="ShmReader",
+        )
+
+    def _prime_current_payload(self) -> None:
+        """Deliver the newest payload when the reader starts late."""
+        # A notification may predate this reader's FIFO opening.
+        payload = self._read_payload()
+        if payload is None:
+            return
+        self._dispatch_payload(payload)
+
+    def _drain_signals(self, signal_file_descriptor: int) -> bool:
+        """Drain a FIFO batch and report whether any token arrived."""
+        signal_received = False
+        for _ in range(SHM_SIGNAL_DRAIN_READS):
+            try:
+                signal_chunk = os.read(
+                    signal_file_descriptor,
+                    SHM_SIGNAL_DRAIN_READ_SIZE,
+                )
+            except BlockingIOError:
+                return signal_received
+            if not signal_chunk:
+                return signal_received
+            signal_received = True
+            if len(signal_chunk) < SHM_SIGNAL_DRAIN_READ_SIZE:
+                return signal_received
+        return signal_received
+
+    def _read_payload(self) -> bytes | None:
+        """Copy one coherent payload snapshot under a shared lock."""
+        lock_file_descriptor = self._lock_file_descriptor
+        if lock_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_READER_LOCK_NOT_OPEN)
+
+        with _channel_lock(lock_file_descriptor, fcntl.LOCK_SH):
+            capacity, payload_length = self._sync_map()
+            if payload_length == 0:
+                # The channel is empty or no writer copy is committed.
+                return None
+
+            memory_map_ = self._memory_map
+            if memory_map_ is None:
+                raise RuntimeError(SHM_ERROR_READER_NOT_OPEN)
+
+            payload = bytes(
+                memory_map_[
+                    SHM_HEADER_SIZE : SHM_HEADER_SIZE + payload_length
+                ],
+            )
+            latest_capacity, latest_payload_length = self._sync_map()
+            # The lock makes this copy coherent.
+            # Keep the header check for non-cooperating writers.
+            if (
+                latest_capacity != capacity
+                or latest_payload_length != payload_length
+            ):
+                return None
+            return payload
+
+    def _wait_for_signal(
+        self,
+        signal_file_descriptor: int,
+    ) -> bool | None:
+        """Poll for a signal, returning ``None`` when polling fails."""
+        try:
+            readable_file_descriptors, _, _ = select.select(
+                [signal_file_descriptor],
+                [],
+                [],
+                SHM_SIGNAL_POLL_TIMEOUT_SECONDS,
+            )
+        except OSError as error:
+            if self._running:
+                message = f"{SHM_ERROR_SIGNAL_POLL_FAILED}: {error}"
+                self._logerr(message)
+            return None
+        return bool(readable_file_descriptors)
+
+    def _read_signaled_payload(
+        self,
+        signal_file_descriptor: int,
+    ) -> bytes | None:
+        """Drain FIFO wake-ups and return the latest payload."""
+        try:
+            signal_received = self._drain_signals(
+                signal_file_descriptor,
+            )
+        except OSError as error:
+            if self._running:
+                message = f"{SHM_ERROR_SIGNAL_READ_FAILED}: {error}"
+                self._logerr(message)
+            self._running = False
+            return None
+
+        if not signal_received or not self._running:
+            return None
+
+        try:
+            return self._read_payload()
+        except Exception as error:  # noqa: BLE001
+            # A malformed payload must not terminate the reader worker.
+            message = f"{SHM_ERROR_READ_PAYLOAD}: {error}"
+            self._logerr(message)
+            return None
+
+    def _dispatch_payload(self, payload: bytes) -> None:
+        """Deliver a payload while keeping the reader worker alive."""
+        try:
+            self._on_payload(payload)
+        except Exception as error:  # noqa: BLE001
+            # Callback failures must not stop the reader worker.
+            message = f"{SHM_ERROR_HANDLE_PAYLOAD}: {error}"
+            self._logerr(message)
+
+    def _reader_loop(self) -> None:
+        """Poll FIFO wake-ups and forward valid snapshots."""
+        signal_file_descriptor = self._signal_file_descriptor
+        if signal_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_READER_NOT_OPEN)
+
+        try:
+            while self._running:
+                signal_ready = self._wait_for_signal(signal_file_descriptor)
+                if signal_ready is None:
+                    return
+                if not signal_ready:
+                    continue
+
+                # FIFO tokens wake this loop.
+                # Payload bytes remain in mmap.
+                payload = self._read_signaled_payload(
+                    signal_file_descriptor,
+                )
+                if payload is None:
+                    continue
+                if not self._running:
+                    return
+                self._dispatch_payload(payload)
+        finally:
+            self._running = False
+            self._close_handles()
+
+    def _remap(self, map_size: int) -> None:
+        """Replace the mapping after a writer grows the backing file."""
+        old_memory_map = self._memory_map
+        self._memory_map = self._open_memory_map(map_size)
+        self._map_size = map_size
+        if old_memory_map is not None:
+            # The old map cannot address bytes past its capacity.
+            old_memory_map.close()
+
+    def _sync_map(self) -> tuple[int, int]:
+        """Read the header and remap under the caller's channel lock."""
+        memory_map_ = self._memory_map
+        if memory_map_ is None:
+            raise RuntimeError(SHM_ERROR_READER_NOT_OPEN)
+
+        # Copy the live header first to preserve a local snapshot.
+        # The snapshot determines whether remapping is required.
+        header = bytes(memory_map_[:SHM_HEADER_SIZE])
+        capacity, payload_length = _unpack_header(header)
+        target_size = SHM_HEADER_SIZE + capacity
+        if target_size != self._map_size:
+            # The writer may have grown the backing file since mapping.
+            self._remap(target_size)
+            memory_map_ = self._memory_map
+            if memory_map_ is None:
+                raise RuntimeError(SHM_ERROR_READER_REMAP_FAILED)
+            header = bytes(memory_map_[:SHM_HEADER_SIZE])
+            capacity, payload_length = _unpack_header(header)
+        return capacity, payload_length
+
+    def _drain_pending_signals(self) -> None:
+        """Discard stale FIFO wake-ups before a fresh session."""
+        signal_file_descriptor = self._signal_file_descriptor
+        if signal_file_descriptor is None:
+            raise RuntimeError(SHM_ERROR_READER_NOT_OPEN)
+        signals_pending = True
+        while signals_pending:
+            signals_pending = self._drain_signals(signal_file_descriptor)
+
+    def start(self, *, deliver_current: bool = True) -> None:
+        """Open the channel and start the reader.
+
+        By default, stored payload primes the reader before startup.
+        Set ``deliver_current`` to ``False`` for a fresh session.
+        Fresh sessions ignore prior producer snapshots and signals.
+        """
+        if self._running:
+            return
+        if self._thread.is_alive():
+            raise RuntimeError(SHM_ERROR_READER_STOPPING)
+        self._ensure_open()
+        if self._thread.ident is not None:
+            # Python threads cannot be started twice after a stop cycle.
+            self._thread = self._create_reader_thread()
+        self._running = True
+        try:
+            if deliver_current:
+                self._prime_current_payload()
+            else:
+                self._drain_pending_signals()
+            if not self._running:
+                return
+            self._thread.start()
+        except Exception:
+            self._running = False
+            self._close_handles()
+            raise
+
+    def stop(self) -> None:
+        """Request worker shutdown and release resources after exit."""
+        self._running = False
+        if current_thread() is self._thread:
+            # The worker closes resources after this callback returns.
+            return
+        if self._thread.is_alive():
+            self._thread.join(timeout=SHM_STOP_JOIN_TIMEOUT_SECONDS)
+        if self._thread.is_alive():
+            self._logwarn(SHM_WARNING_READER_STILL_STOPPING)
+            return
+        self._close_handles()

--- a/src/dtps_http_tests/test_shm.py
+++ b/src/dtps_http_tests/test_shm.py
@@ -1,0 +1,1509 @@
+"""Regression tests for the latest-value shared-memory transport.
+
+The tests exercise cross-process locking, FIFO wake-up coalescing, mapping
+resizes, channel isolation, and reader lifecycle behavior.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import stat
+import struct
+import tempfile
+import threading
+import unittest
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import dtps_http.shm as shm_module
+from dtps_http.shm import ShmReader, ShmWriter
+
+fcntl: Any = None
+with suppress(ImportError):
+    import fcntl
+
+_REQUIRED_FCNTL_CAPABILITIES = (
+    "flock",
+    "LOCK_EX",
+    "LOCK_SH",
+    "LOCK_UN",
+)
+_REQUIRED_OS_CAPABILITIES = (
+    "O_CLOEXEC",
+    "O_NOFOLLOW",
+    "O_NONBLOCK",
+    "chmod",
+    "fchmod",
+    "ftruncate",
+    "geteuid",
+    "mkfifo",
+    "pread",
+    "pwrite",
+)
+
+
+def _has_required_capabilities(
+    module: object,
+    capabilities: tuple[str, ...],
+) -> bool:
+    """Return whether *module* provides every named capability."""
+    for capability in capabilities:
+        if getattr(module, capability, None) is None:
+            return False
+    return True
+
+
+_SHM_TEST_SUPPORTED = (
+    os.name == "posix"
+    and fcntl is not None
+    and _has_required_capabilities(
+        fcntl,
+        _REQUIRED_FCNTL_CAPABILITIES,
+    )
+    and _has_required_capabilities(os, _REQUIRED_OS_CAPABILITIES)
+)
+
+
+def _hold_shared_lock(lock_path, lock_acquired, release_lock) -> None:
+    """Hold a process-shared read lock until the parent releases this helper."""
+    lock_file_descriptor = os.open(lock_path, os.O_RDWR)
+    try:
+        fcntl.flock(lock_file_descriptor, fcntl.LOCK_SH)
+        lock_acquired.set()
+        release_lock.wait()
+    finally:
+        fcntl.flock(lock_file_descriptor, fcntl.LOCK_UN)
+        os.close(lock_file_descriptor)
+
+
+@unittest.skipUnless(
+    _SHM_TEST_SUPPORTED,
+    "Shared-memory transport tests require POSIX capabilities.",
+)
+class SharedMemoryTransportTests(unittest.TestCase):
+    """Exercise the public safety and delivery contract of shared memory."""
+
+    def test_close_handles_clears_state_after_close_failures(self):
+        """Detach every handle when its close operation fails."""
+        errors: list[str] = []
+        failing_map = Mock()
+        failing_map.close.side_effect = BufferError("exported buffer")
+        endpoint = object.__new__(shm_module._ShmEndpoint)
+        endpoint._memory_map = failing_map
+        endpoint._signal_file_descriptor = 10
+        endpoint._lock_file_descriptor = 11
+        endpoint._logerr = errors.append
+
+        with patch.object(
+            shm_module.os,
+            "close",
+            side_effect=[
+                OSError("signal close failed"),
+                OSError("lock close failed"),
+            ],
+        ):
+            endpoint._close_handles()
+
+        self.assertIsNone(endpoint._memory_map)
+        self.assertIsNone(endpoint._signal_file_descriptor)
+        self.assertIsNone(endpoint._lock_file_descriptor)
+        self.assertEqual(
+            errors,
+            [
+                f"{shm_module.SHM_ERROR_CLOSE_MAP}: exported buffer",
+                f"{shm_module.SHM_ERROR_CLOSE_SIGNAL_FIFO}: "
+                "signal close failed",
+                f"{shm_module.SHM_ERROR_CLOSE_LOCK_FILE}: "
+                "lock close failed",
+            ],
+        )
+
+    def test_writer_rejects_missing_fcntl_capability(self):
+        """Fail clearly before creating files when advisory locks are absent."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "missing-fcntl"
+            with patch.object(shm_module, "fcntl", None), self.assertRaisesRegex(OSError, "fcntl"):
+                ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+            channel_exists = channel_path.exists()
+
+        self.assertFalse(channel_exists)
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_writer_rejects_missing_no_follow_capability(self):
+        """Fail clearly before creating files when no-follow opens are absent."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "missing-no-follow"
+            with patch.object(shm_module.os, "O_NOFOLLOW", None), self.assertRaisesRegex(OSError, "os.O_NOFOLLOW"):
+                ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+            channel_exists = channel_path.exists()
+
+        self.assertFalse(channel_exists)
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_writer_rejects_missing_close_on_exec_capability(self):
+        """Fail clearly before creating files without close-on-exec opens."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "missing-close-on-exec"
+            with patch.object(
+                shm_module.os,
+                "O_CLOEXEC",
+                None,
+            ), self.assertRaisesRegex(OSError, "os.O_CLOEXEC"):
+                ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+            channel_exists = channel_path.exists()
+
+        self.assertFalse(channel_exists)
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_writer_opens_channel_artifacts_close_on_exec(self):
+        """Set close-on-exec on every channel artifact descriptor."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        original_open = os.open
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "close-on-exec"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with patch.object(
+                    shm_module.os,
+                    "open",
+                    wraps=original_open,
+                ) as open_method:
+                    writer.publish(b"payload")
+                open_calls = open_method.call_args_list
+            finally:
+                writer.close()
+
+        open_flags = [open_call.args[1] for open_call in open_calls]
+        self.assertTrue(open_flags)
+        for open_flags_value in open_flags:
+            close_on_exec = open_flags_value & os.O_CLOEXEC
+            self.assertEqual(close_on_exec, os.O_CLOEXEC)
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_new_channel_files_are_owner_only(self):
+        """Create data, lock, and signal entries with owner-only access."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "private-channel"
+            lock_path = channel_path.parent / f"{channel_path.name}.lock"
+            signal_path = channel_path.parent / f"{channel_path.name}.p2c"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"payload")
+                for path in (
+                    channel_path,
+                    lock_path,
+                    signal_path,
+                ):
+                    path_status = path.stat()
+                    mode = stat.S_IMODE(path_status.st_mode)
+                    self.assertEqual(mode, 0o600)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_resets_oversized_corrupt_channel(self):
+        """Discard an untrusted backing-file size with an invalid header."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "oversized-corrupt-channel"
+            oversized_capacity = shm_module.SHM_DEFAULT_CAPACITY * 8
+            oversized_file_size = (
+                shm_module.SHM_HEADER_SIZE + oversized_capacity
+            )
+            channel_path.write_bytes(b"invalid header")
+            os.truncate(channel_path, oversized_file_size)
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"payload")
+                channel_size = channel_path.stat().st_size
+            finally:
+                writer.close()
+
+        expected_size = (
+            shm_module.SHM_HEADER_SIZE + shm_module.SHM_DEFAULT_CAPACITY
+        )
+        self.assertEqual(channel_size, expected_size)
+        self.assertTrue(warnings)
+        self.assertFalse(errors)
+
+    def test_writer_resets_channel_with_excessive_capacity(self):
+        """Discard a valid header that exceeds the capacity ceiling."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "excessive-capacity-channel"
+            excessive_capacity = shm_module.SHM_MAX_CAPACITY + 1
+            header = struct.pack(
+                shm_module.SHM_HEADER_FORMAT,
+                shm_module.SHM_MAGIC,
+                shm_module.SHM_VERSION,
+                excessive_capacity,
+                0,
+            )
+            channel_path.write_bytes(header)
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"payload")
+                channel_size = channel_path.stat().st_size
+            finally:
+                writer.close()
+
+        expected_size = (
+            shm_module.SHM_HEADER_SIZE + shm_module.SHM_DEFAULT_CAPACITY
+        )
+        self.assertEqual(channel_size, expected_size)
+        self.assertTrue(warnings)
+        self.assertFalse(errors)
+
+    def test_header_rejects_negative_capacity(self):
+        """Reject a negative capacity before writing a channel header."""
+        with self.assertRaises(ValueError):
+            shm_module._pack_header(-1, 0)
+
+    def test_writer_rejects_payload_exceeding_capacity_ceiling(self):
+        """Reject a write that would grow the channel beyond its ceiling."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with patch.multiple(
+            shm_module,
+            SHM_DEFAULT_CAPACITY=8,
+            SHM_MAX_CAPACITY=16,
+        ), tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "oversized-payload"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "exceeds configured maximum",
+                ):
+                    writer.publish(b"x" * 17)
+                channel_size = channel_path.stat().st_size
+            finally:
+                writer.close()
+
+        expected_size = shm_module.SHM_HEADER_SIZE + 8
+        self.assertEqual(channel_size, expected_size)
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_writer_recovers_without_leaking_handles_after_write_failure(
+        self,
+    ):
+        """Close partial state before reopening after a mapped write fails."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        opened_signal_file_descriptors: list[int] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "failed-write"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+
+            def fail_after_map_close(
+                _payload: bytes,
+                _payload_length: int,
+            ) -> None:
+                signal_file_descriptor = writer._signal_file_descriptor
+                assert signal_file_descriptor is not None
+                opened_signal_file_descriptors.append(signal_file_descriptor)
+                memory_map = writer._memory_map
+                assert memory_map is not None
+                memory_map.close()
+                writer._memory_map = None
+                raise OSError("simulated mapped write failure")
+
+            try:
+                with patch.object(
+                    writer,
+                    "_write_payload_locked",
+                    side_effect=fail_after_map_close,
+                ), self.assertRaisesRegex(OSError, "simulated mapped write"):
+                    writer.publish(b"payload")
+
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+                self.assertIsNone(writer._lock_file_descriptor)
+                with self.assertRaises(OSError):
+                    os.fstat(opened_signal_file_descriptors[0])
+
+                writer.publish(b"recovered")
+            finally:
+                writer.close()
+
+        self.assertFalse(warnings)
+        self.assertFalse(errors)
+
+    def test_new_channel_files_ignore_restrictive_umask(self):
+        """Correct new channel directory and entry modes after a strict umask."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_directory = Path(directory) / "umask-directory"
+            channel_path = channel_directory / "umask-channel"
+            lock_path = channel_path.parent / f"{channel_path.name}.lock"
+            signal_path = channel_path.parent / f"{channel_path.name}.p2c"
+            previous_umask = os.umask(0o777)
+            writer: ShmWriter | None = None
+            try:
+                writer = ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+                writer.publish(b"payload")
+            finally:
+                os.umask(previous_umask)
+                if writer is not None:
+                    writer.close()
+
+            for path in (
+                channel_path,
+                lock_path,
+                signal_path,
+            ):
+                path_status = path.stat()
+                mode = stat.S_IMODE(path_status.st_mode)
+                self.assertEqual(mode, 0o600)
+            directory_status = channel_directory.stat()
+            directory_mode = stat.S_IMODE(directory_status.st_mode)
+            self.assertEqual(directory_mode, 0o700)
+
+        self.assertFalse(errors)
+
+    def test_nested_channel_directories_ignore_restrictive_umask(self):
+        """Repair each new parent before creating the next channel directory."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            first_directory = Path(directory) / "first-directory"
+            second_directory = first_directory / "second-directory"
+            channel_path = second_directory / "channel"
+            previous_umask = os.umask(0o777)
+            writer: ShmWriter | None = None
+            try:
+                writer = ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+                writer.publish(b"payload")
+            finally:
+                os.umask(previous_umask)
+                if writer is not None:
+                    writer.close()
+
+            for channel_directory in (first_directory, second_directory):
+                directory_status = channel_directory.stat()
+                directory_mode = stat.S_IMODE(directory_status.st_mode)
+                self.assertEqual(directory_mode, 0o700)
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_world_writable_channel_directory(self):
+        """Reject channel artifacts located directly in a public directory."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_directory = Path(directory) / "public-directory"
+            channel_directory.mkdir(mode=0o700)
+            channel_directory.chmod(0o707)
+            channel_path = channel_directory / "channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    ValueError, "writable by other users"
+                ):
+                    writer.publish(b"payload")
+                self.assertFalse(channel_path.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_group_writable_channel_directory(self):
+        """Reject channel artifacts located directly in a shared directory."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_directory = Path(directory) / "shared-directory"
+            channel_directory.mkdir(mode=0o700)
+            channel_directory.chmod(0o770)
+            channel_path = channel_directory / "channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    ValueError, "writable by other users"
+                ):
+                    writer.publish(b"payload")
+                self.assertFalse(channel_path.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_writable_channel_directory_ancestor(self):
+        """Reject a channel below an ancestor an untrusted user can replace."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            shared_parent = Path(directory) / "shared-parent"
+            shared_parent.mkdir(mode=0o700)
+            shared_parent.chmod(0o777)
+            channel_directory = shared_parent / "private-directory"
+            channel_path = channel_directory / "channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    ValueError, "writable by other users"
+                ):
+                    writer.publish(b"payload")
+                self.assertFalse(channel_directory.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_allows_sticky_channel_directory_ancestor(self):
+        """Allow a private channel nested below a sticky shared parent."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            sticky_parent = Path(directory) / "sticky-parent"
+            sticky_parent.mkdir(mode=0o700)
+            sticky_parent.chmod(0o1777)
+            channel_path = sticky_parent / "private-directory" / "channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"payload")
+                self.assertTrue(channel_path.exists())
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_symlinked_channel_directory(self):
+        """Reject a channel directory that resolves through a symlink."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            target_directory = Path(directory) / "target-directory"
+            target_directory.mkdir(mode=0o700)
+            channel_directory = Path(directory) / "symlinked-directory"
+            channel_directory.symlink_to(
+                target_directory, target_is_directory=True
+            )
+            channel_path = channel_directory / "channel"
+            target_channel_path = target_directory / "channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "is a symlink"):
+                    writer.publish(b"payload")
+                self.assertFalse(target_channel_path.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_channel_directory_with_symlinked_parent(self):
+        """Reject a new channel directory below a symlinked parent."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            target_directory = Path(directory) / "target-directory"
+            target_directory.mkdir(mode=0o700)
+            symlinked_parent = Path(directory) / "symlinked-parent"
+            symlinked_parent.symlink_to(
+                target_directory, target_is_directory=True
+            )
+            channel_directory = symlinked_parent / "new-directory"
+            channel_path = channel_directory / "channel"
+            target_channel_directory = target_directory / "new-directory"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "is a symlink"):
+                    writer.publish(b"payload")
+                self.assertFalse(target_channel_directory.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_channel_file_fallback_does_not_create_after_race(self):
+        """Do not recreate an artifact that vanishes after an EEXIST race."""
+        open_flags = os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW
+        open_calls: list[tuple[int, int | None]] = []
+
+        def open_file(
+            _path: str,
+            flags: int,
+            mode: int | None = None,
+        ) -> int:
+            open_calls.append((flags, mode))
+            if len(open_calls) == 1:
+                raise FileExistsError
+            raise FileNotFoundError
+
+        with patch.object(
+            shm_module.os,
+            "open",
+            side_effect=open_file,
+        ), self.assertRaises(FileNotFoundError):
+            shm_module._open_or_create_channel_file(
+                "channel",
+                open_flags,
+                0o600,
+            )
+
+        fallback_flags, fallback_mode = open_calls[1]
+        self.assertFalse(fallback_flags & os.O_CREAT)
+        self.assertFalse(fallback_flags & os.O_EXCL)
+        self.assertIsNone(fallback_mode)
+
+    def test_independent_channels_deliver_only_their_payloads(self):
+        """Keep payloads isolated by their independent channel paths."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        payloads = {
+            "alpha": b"alpha-payload",
+            "beta": b"beta-payload",
+            "gamma": b"gamma-payload",
+        }
+        received = {channel_name: [] for channel_name in payloads}
+        writers = []
+        readers = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            for channel_name, payload in payloads.items():
+                channel_path = Path(directory) / channel_name
+                writer = ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+                writer.publish(payload)
+                reader = ShmReader(
+                    channel_path,
+                    received[channel_name].append,
+                    warnings.append,
+                    errors.append,
+                )
+                writers.append(writer)
+                readers.append(reader)
+
+            try:
+                for reader in readers:
+                    reader.start()
+            finally:
+                for reader in readers:
+                    reader.stop()
+                for writer in writers:
+                    writer.close()
+
+        for channel_name, payload in payloads.items():
+            channel_payloads = received[channel_name]
+            self.assertTrue(channel_payloads)
+            all_payloads_match = all(
+                received_payload == payload
+                for received_payload in channel_payloads
+            )
+            self.assertTrue(all_payloads_match)
+        self.assertFalse(errors)
+
+    def test_reader_receives_resized_payload(self):
+        """Deliver a complete payload after the writer grows its backing map."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "resized-payload"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                received.append,
+                warnings.append,
+                errors.append,
+            )
+            payload = b"x" * ((1024 * 1024) + 1)
+            try:
+                writer.publish(payload)
+                reader.start()
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertTrue(received)
+        all_payloads_match = all(
+            received_payload == payload for received_payload in received
+        )
+        self.assertTrue(all_payloads_match)
+        self.assertFalse(errors)
+
+    def test_reader_retries_remap_after_transient_map_failure(self):
+        """Keep the prior map usable when one resize remap cannot open."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "retry-remap"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                lambda _payload: None,
+                warnings.append,
+                errors.append,
+            )
+            payload = b"x" * (shm_module.SHM_DEFAULT_CAPACITY + 1)
+            original_open_memory_map = reader._open_memory_map
+            map_attempts = 0
+
+            def fail_once(map_size: int):
+                nonlocal map_attempts
+                map_attempts += 1
+                if map_attempts == 1:
+                    raise OSError("transient mapping failure")
+                return original_open_memory_map(map_size)
+
+            try:
+                writer.publish(b"initial")
+                reader._ensure_open()
+                writer.publish(payload)
+                with patch.object(
+                    reader,
+                    "_open_memory_map",
+                    side_effect=fail_once,
+                ):
+                    with self.assertRaisesRegex(
+                        OSError,
+                        "transient mapping failure",
+                    ):
+                        reader._read_payload()
+                    self.assertEqual(reader._read_payload(), payload)
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertEqual(map_attempts, 2)
+        self.assertFalse(errors)
+
+    def test_writer_waits_for_shared_channel_lock(self):
+        """Block an exclusive writer update until another process releases LOCK_SH."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        publish_started = threading.Event()
+        publish_completed = threading.Event()
+        publish_errors: list[Exception] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "locked-channel"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            writer.publish(b"before")
+
+            lock_path = str(channel_path) + ".lock"
+            # Use a separate process so this verifies the kernel-level flock
+            # contract rather than thread-local behavior in one interpreter.
+            lock_acquired = multiprocessing.Event()
+            release_lock = multiprocessing.Event()
+            lock_process = multiprocessing.Process(
+                target=_hold_shared_lock,
+                args=(lock_path, lock_acquired, release_lock),
+            )
+            lock_process.start()
+
+            def publish() -> None:
+                publish_started.set()
+                try:
+                    writer.publish(b"after")
+                except Exception as error:  # pragma: no cover - asserted below
+                    publish_errors.append(error)
+                finally:
+                    publish_completed.set()
+
+            publish_thread = threading.Thread(target=publish)
+            try:
+                self.assertTrue(lock_acquired.wait(1))
+                publish_thread.start()
+                self.assertTrue(publish_started.wait(1))
+                self.assertFalse(publish_completed.wait(0.1))
+
+                release_lock.set()
+                self.assertTrue(publish_completed.wait(1))
+                publish_thread.join(timeout=1)
+            finally:
+                # Always unblock and reap the helper, even after an assertion.
+                release_lock.set()
+                lock_process.join(timeout=1)
+                if lock_process.is_alive():
+                    lock_process.terminate()
+                    lock_process.join(timeout=1)
+                writer.close()
+
+        self.assertFalse(publish_thread.is_alive())
+        self.assertEqual(lock_process.exitcode, 0)
+        self.assertFalse(publish_errors)
+        self.assertFalse(errors)
+
+    def test_writer_rejects_non_fifo_signal_path(self):
+        """Reject a regular file at the signal path and release setup resources."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "invalid-signal"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            signal_path.touch()
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "not a FIFO"):
+                    writer.publish(b"payload")
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_symlinked_signal_path(self):
+        """Reject a symlink even when it resolves to a valid FIFO."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "symlinked-signal"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            target_path = Path(directory) / "signal-target"
+            os.mkfifo(target_path, 0o600)
+            signal_path.symlink_to(target_path)
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "not a FIFO"):
+                    writer.publish(b"payload")
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_existing_public_signal_fifo(self):
+        """Reject a pre-existing FIFO that other users can access."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "public-signal"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            os.mkfifo(signal_path, 0o600)
+            signal_path.chmod(0o606)
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    ValueError, "accessible by other users"
+                ):
+                    writer.publish(b"payload")
+                signal_status = signal_path.stat()
+                signal_mode = stat.S_IMODE(signal_status.st_mode)
+                self.assertEqual(signal_mode, 0o606)
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_symlinked_backing_and_lock_paths(self):
+        """Do not follow symlinks for regular channel artifacts."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        for suffix in ("", ".lock"):
+            with self.subTest(suffix=suffix), tempfile.TemporaryDirectory() as directory:
+                channel_path = Path(directory) / "symlinked-channel"
+                protected_path = Path(directory) / "protected"
+                protected_payload = b"do not overwrite"
+                protected_path.write_bytes(protected_payload)
+                artifact_name = f"{channel_path.name}{suffix}"
+                artifact_path = channel_path.parent / artifact_name
+                artifact_path.symlink_to(protected_path)
+                writer = ShmWriter(
+                    channel_path,
+                    warnings.append,
+                    errors.append,
+                )
+                try:
+                    with self.assertRaisesRegex(
+                        ValueError, "regular file"
+                    ):
+                        writer.publish(b"payload")
+                    self.assertEqual(
+                        protected_path.read_bytes(),
+                        protected_payload,
+                    )
+                    self.assertIsNone(writer._lock_file_descriptor)
+                    self.assertIsNone(writer._memory_map)
+                    self.assertIsNone(writer._signal_file_descriptor)
+                finally:
+                    writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_invalid_backing_before_creating_signal(self):
+        """Avoid a partial FIFO when the backing channel path is invalid."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "invalid-backing"
+            protected_path = Path(directory) / "protected"
+            protected_path.write_bytes(b"do not overwrite")
+            channel_path.symlink_to(protected_path)
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "regular file"):
+                    writer.publish(b"payload")
+                signal_exists = signal_path.exists()
+                self.assertFalse(signal_exists)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_removes_new_signal_after_map_failure(self):
+        """Remove a FIFO created during an unsuccessful channel open."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "map-failure"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with patch.object(writer, "_open_memory_map", side_effect=OSError("mapping failed")), self.assertRaisesRegex(OSError, "mapping failed"):
+                    writer.publish(b"payload")
+                self.assertFalse(signal_path.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_ensure_signal_fifo_corrects_restrictive_umask(self):
+        """Repair a new FIFO's mode before opening its descriptor."""
+        with tempfile.TemporaryDirectory() as directory:
+            signal_path = Path(directory) / "signal.p2c"
+            signal_file_descriptor: int | None = None
+            signal_mode: int | None = None
+            previous_umask = os.umask(0o777)
+            try:
+                signal_created, _signal_identity = (
+                    shm_module._ensure_signal_fifo(str(signal_path))
+                )
+            finally:
+                os.umask(previous_umask)
+            try:
+                self.assertTrue(signal_created)
+                signal_file_descriptor = shm_module._open_signal_fifo(
+                    str(signal_path),
+                    created=signal_created,
+                )
+                signal_mode = stat.S_IMODE(
+                    os.fstat(signal_file_descriptor).st_mode
+                )
+            finally:
+                if signal_file_descriptor is not None:
+                    os.close(signal_file_descriptor)
+                if signal_path.exists():
+                    signal_path.unlink()
+
+        self.assertEqual(signal_mode, 0o600)
+
+    def test_ensure_signal_fifo_removes_path_after_validation_failure(self):
+        """Remove a FIFO created before its setup validation fails."""
+        with tempfile.TemporaryDirectory() as directory:
+            signal_path = Path(directory) / "signal.p2c"
+            with patch.object(
+                shm_module,
+                "_validate_signal_fifo_status",
+                side_effect=ValueError("validation failed"),
+            ), self.assertRaisesRegex(ValueError, "validation failed"):
+                shm_module._ensure_signal_fifo(str(signal_path))
+            self.assertFalse(signal_path.exists())
+
+    def test_writer_removes_new_signal_after_fifo_setup_failure(self):
+        """Remove a FIFO when its initial permission setup fails."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        original_fchmod = os.fchmod
+
+        def fail_signal_fchmod(file_descriptor: int, mode: int) -> None:
+            file_status = os.fstat(file_descriptor)
+            if stat.S_ISFIFO(file_status.st_mode):
+                raise OSError("chmod failed")
+            original_fchmod(file_descriptor, mode)
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "fifo-setup-failure"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with patch.object(
+                    shm_module.os,
+                    "fchmod",
+                    side_effect=fail_signal_fchmod,
+                ), self.assertRaisesRegex(OSError, "chmod failed"):
+                    writer.publish(b"payload")
+                self.assertFalse(signal_path.exists())
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_preserves_replaced_signal_after_fifo_setup_failure(self):
+        """Do not remove a path substituted during FIFO setup cleanup."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        replacement_payload = b"replacement"
+        original_fchmod = os.fchmod
+
+        def replace_signal_then_fail(
+            signal_file_descriptor: int,
+            mode: int,
+        ) -> None:
+            signal_status = os.fstat(signal_file_descriptor)
+            if not stat.S_ISFIFO(signal_status.st_mode):
+                original_fchmod(signal_file_descriptor, mode)
+                return
+            signal_path.unlink()
+            signal_path.write_bytes(replacement_payload)
+            raise OSError("chmod failed")
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "fifo-setup-replacement"
+            signal_name = f"{channel_path.name}.p2c"
+            signal_path = channel_path.parent / signal_name
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with patch.object(
+                    shm_module.os,
+                    "fchmod",
+                    side_effect=replace_signal_then_fail,
+                ), self.assertRaisesRegex(OSError, "chmod failed"):
+                    writer.publish(b"payload")
+                self.assertEqual(signal_path.read_bytes(), replacement_payload)
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_rejects_hardlinked_backing_path(self):
+        """Do not truncate an existing file linked into a channel path."""
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "hardlinked-channel"
+            protected_path = Path(directory) / "protected"
+            protected_payload = b"do not overwrite"
+            protected_path.write_bytes(protected_payload)
+            os.link(protected_path, channel_path)
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "multiple hard links"):
+                    writer.publish(b"payload")
+                self.assertEqual(
+                    protected_path.read_bytes(), protected_payload
+                )
+                self.assertIsNone(writer._lock_file_descriptor)
+                self.assertIsNone(writer._memory_map)
+                self.assertIsNone(writer._signal_file_descriptor)
+            finally:
+                writer.close()
+
+        self.assertFalse(errors)
+
+    def test_writer_coalesces_notifications_when_fifo_is_full(self):
+        """Keep publishing when the FIFO is full and warn only once per episode."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        publish_completed = threading.Event()
+        publish_errors: list[Exception] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "full-fifo"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            writer.publish(b"initial")
+
+            signal_path = str(channel_path) + ".p2c"
+            fill_flags = os.O_RDWR | os.O_NONBLOCK
+            fill_file_descriptor = os.open(signal_path, fill_flags)
+            fill_chunk = b"x" * 8192
+            fifo_is_full = False
+            try:
+                # No reader drains this descriptor, so non-blocking writes
+                # eventually prove that the FIFO has reached backpressure.
+                for _ in range(1024):
+                    try:
+                        os.write(fill_file_descriptor, fill_chunk)
+                    except BlockingIOError:
+                        fifo_is_full = True
+                        break
+                self.assertTrue(fifo_is_full)
+
+                def publish() -> None:
+                    try:
+                        writer.publish(b"latest")
+                    except (
+                        Exception
+                    ) as error:  # pragma: no cover - asserted below
+                        publish_errors.append(error)
+                    finally:
+                        publish_completed.set()
+
+                publish_thread = threading.Thread(target=publish, daemon=True)
+                publish_thread.start()
+                self.assertTrue(publish_completed.wait(1))
+                publish_thread.join(timeout=1)
+                self.assertFalse(publish_thread.is_alive())
+                # A second full-FIFO publish must not duplicate the warning.
+                writer.publish(b"newest")
+            finally:
+                os.close(fill_file_descriptor)
+                writer.close()
+
+        self.assertFalse(publish_errors)
+        backpressure_warnings = [
+            warning for warning in warnings if "signal FIFO is full" in warning
+        ]
+        self.assertEqual(len(backpressure_warnings), 1)
+        self.assertFalse(errors)
+
+    def test_reader_coalesces_queued_wakeups(self):
+        """Turn a queued FIFO batch into one latest-payload callback."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+        received_lock = threading.Lock()
+        queued_delivery_received = threading.Event()
+
+        def on_payload(payload: bytes) -> None:
+            """Record startup priming and the following coalesced delivery."""
+            with received_lock:
+                received.append(payload)
+                received_count = len(received)
+            if received_count >= 2:
+                queued_delivery_received.set()
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "queued-wakeups"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            payload = b"latest"
+            # Each token is eight bytes. 512 tokens make one exact 4096-byte
+            # reader drain, covering the boundary between drain iterations.
+            for _ in range(512):
+                writer.publish(payload)
+
+            reader = ShmReader(
+                channel_path,
+                on_payload,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                reader.start()
+                self.assertTrue(queued_delivery_received.wait(1))
+            finally:
+                reader.stop()
+                writer.close()
+
+        with received_lock:
+            self.assertEqual(len(received), 2)
+        all_payloads_match = all(
+            received_payload == payload for received_payload in received
+        )
+        # The first callback primes the existing payload; the second represents
+        # the complete queued wake-up batch.
+        self.assertTrue(all_payloads_match)
+        self.assertFalse(errors)
+
+    def test_reader_can_restart_after_stop(self):
+        """Create a fresh worker thread and deliver payloads after a restart."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "restartable-reader"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                received.append,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                first_payload = b"first"
+                writer.publish(first_payload)
+                reader.start()
+                reader.stop()
+
+                second_payload = b"second"
+                writer.publish(second_payload)
+                reader.start()
+                reader.stop()
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertIn(first_payload, received)
+        self.assertIn(second_payload, received)
+        self.assertFalse(errors)
+
+    def test_reader_continues_after_startup_callback_error(self):
+        """Log a retained-payload callback failure without aborting startup."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+        received_event = threading.Event()
+        retained_payload = b"retained"
+        next_payload = b"next"
+
+        def on_payload(payload: bytes) -> None:
+            if payload == retained_payload:
+                raise RuntimeError("retained callback failure")
+            received.append(payload)
+            received_event.set()
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "startup-callback-error"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                on_payload,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(retained_payload)
+                reader.start()
+                writer.publish(next_payload)
+                next_payload_received = received_event.wait(1)
+                self.assertTrue(next_payload_received)
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertIn(next_payload, received)
+        callback_errors = [
+            error
+            for error in errors
+            if "Failed to handle shared-memory payload" in error
+        ]
+        self.assertTrue(callback_errors)
+
+    def test_fresh_reader_skips_previous_session_payload(self):
+        """Discard retained payloads and wake-ups before a fresh session."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+        received_event = threading.Event()
+
+        def on_payload(payload: bytes) -> None:
+            received.append(payload)
+            received_event.set()
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "fresh-reader"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                on_payload,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"previous-session")
+                with patch.multiple(
+                    "dtps_http.shm",
+                    SHM_SIGNAL_DRAIN_READ_SIZE=1,
+                    SHM_SIGNAL_DRAIN_READS=1,
+                ):
+                    reader.start(deliver_current=False)
+                self.assertFalse(received_event.wait(0.1))
+
+                writer.publish(b"current-session")
+                self.assertTrue(received_event.wait(1))
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertEqual(received, [b"current-session"])
+        self.assertFalse(errors)
+
+    def test_writer_can_clear_a_retained_payload(self):
+        """A new producer can prevent its stale payload from being primed."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        received: list[bytes] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "clear-retained"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                received.append,
+                warnings.append,
+                errors.append,
+            )
+            try:
+                writer.publish(b"previous-session")
+                writer.clear()
+                reader.start()
+            finally:
+                reader.stop()
+                writer.close()
+
+        self.assertEqual(received, [])
+        self.assertFalse(errors)
+
+    def test_stop_waits_for_in_flight_callback_before_closing_handles(self):
+        """Defer cleanup until a callback that outlives stop() has returned."""
+        warnings: list[str] = []
+        errors: list[str] = []
+        callback_started = threading.Event()
+        release_callback = threading.Event()
+        received: list[bytes] = []
+
+        def on_payload(payload: bytes) -> None:
+            """Keep the worker active while the test requests shutdown."""
+            callback_started.set()
+            release_callback.wait()
+            received.append(payload)
+
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "in-flight-callback"
+            writer = ShmWriter(
+                channel_path,
+                warnings.append,
+                errors.append,
+            )
+            reader = ShmReader(
+                channel_path,
+                on_payload,
+                warnings.append,
+                errors.append,
+            )
+            payload = b"payload"
+            try:
+                reader.start()
+                writer.publish(payload)
+                self.assertTrue(callback_started.wait(1))
+
+                # stop() must not close resources that its worker still needs.
+                reader.stop()
+                self.assertTrue(reader._thread.is_alive())
+                self.assertIsNotNone(reader._memory_map)
+                self.assertIsNotNone(reader._lock_file_descriptor)
+                with self.assertRaisesRegex(RuntimeError, "still stopping"):
+                    reader.start()
+
+                # Cleanup is owned by the worker after the callback unblocks.
+                release_callback.set()
+                reader._thread.join(timeout=1)
+                self.assertFalse(reader._thread.is_alive())
+                self.assertIsNone(reader._memory_map)
+                self.assertIsNone(reader._lock_file_descriptor)
+            finally:
+                release_callback.set()
+                reader.stop()
+                writer.close()
+
+        self.assertIn(payload, received)
+        self.assertFalse(errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/dtps_tests/test_ergo_3_unsubscribe.py
+++ b/src/dtps_tests/test_ergo_3_unsubscribe.py
@@ -1,9 +1,15 @@
 import asyncio
-from typing import List
+from typing import Any, List
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock, patch
 
 from dtps import DTPSContext
-from dtps_http import async_error_catcher, MIME_TEXT, RawData
+from dtps.ergo_create import (
+    ContextManagerCreate,
+    ContextManagerCreateContext,
+    ContextManagerCreateContextSubscriber,
+)
+from dtps_http import async_error_catcher, MIME_TEXT, RawData, SUB_ID
 from dtps_http_tests.utils import test_timeout
 from dtps_tests import logger
 from dtps_tests.utils import create_use_pair
@@ -79,3 +85,150 @@ class TestErgoUnsub(IsolatedAsyncioTestCase):
                 context_use,
                 inline=False,
             )
+
+
+class TestCreateSubscriptionLifecycle(IsolatedAsyncioTestCase):
+    async def test_create_manager_unsubscribes_tracked_subscriptions(
+        self,
+    ) -> None:
+        """Stop tracked create-side subscriptions during manager shutdown."""
+        subscription = Mock()
+        subscription.unsubscribe = AsyncMock()
+        manager = object.__new__(ContextManagerCreate)
+        manager._subscriptions = {subscription}
+
+        await manager._unsubscribe_all()
+
+        subscription.unsubscribe.assert_awaited_once()
+        self.assertEqual(manager._subscriptions, set())
+
+    async def test_create_subscription_stops_processor(self) -> None:
+        """Cancel and await a create-side callback worker on unsubscribe."""
+        processor_started = asyncio.Event()
+        processor_cancelled = asyncio.Event()
+        object_queue = Mock()
+        object_queue.unsubscribe = AsyncMock()
+        manager = Mock()
+
+        async def process() -> None:
+            processor_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                processor_cancelled.set()
+                raise
+
+        processor_task = asyncio.create_task(process())
+        subscription_id = SUB_ID(1)
+        subscription = ContextManagerCreateContextSubscriber(
+            manager,
+            subscription_id,
+            object_queue,
+            processor_task,
+            asyncio.Event(),
+        )
+        try:
+            await processor_started.wait()
+            await subscription.unsubscribe()
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        object_queue.unsubscribe.assert_awaited_once_with(subscription_id)
+        manager.forget_subscription.assert_called_once_with(subscription)
+        self.assertTrue(processor_cancelled.is_set())
+        self.assertTrue(processor_task.done())
+
+    async def test_create_callback_can_unsubscribe_itself(self) -> None:
+        """Finish a create-side callback that stops its own subscription."""
+        callback_finished = asyncio.Event()
+        object_queue = Mock()
+        object_queue.stored = False
+        object_queue.unsubscribe = AsyncMock()
+        captured_callbacks: List[Any] = []
+
+        def capture_callback(
+            callback: object,
+            **_kwargs: object,
+        ) -> SUB_ID:
+            captured_callbacks.append(callback)
+            return SUB_ID(1)
+
+        object_queue.subscribe.side_effect = capture_callback
+        server = Mock()
+        server.get_oq.return_value = object_queue
+        manager = Mock()
+        manager.remember_subscription = AsyncMock()
+        context = object.__new__(ContextManagerCreateContext)
+        context.master = manager
+        context._topic = Mock()
+        subscription_holder: List[ContextManagerCreateContextSubscriber] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            subscription = subscription_holder[0]
+            await subscription.unsubscribe()
+            callback_finished.set()
+
+        with patch.object(
+            ContextManagerCreateContext,
+            "_get_server",
+            return_value=server,
+        ):
+            subscription = await context.subscribe(on_data)
+        assert isinstance(
+            subscription,
+            ContextManagerCreateContextSubscriber,
+        )
+        subscription_holder.append(subscription)
+        wrapped_callback = captured_callbacks[0]
+        notification = Mock()
+        notification.raw_data = RawData(
+            content=b"payload",
+            content_type=MIME_TEXT,
+        )
+        await wrapped_callback(object_queue, notification)
+
+        await asyncio.wait_for(callback_finished.wait(), timeout=1)
+        await asyncio.wait_for(subscription._processor_task, timeout=1)
+
+        object_queue.unsubscribe.assert_awaited_once_with(subscription.sub_id)
+        manager.forget_subscription.assert_called_once_with(subscription)
+        self.assertFalse(subscription._processor_task.cancelled())
+
+    async def test_create_subscribe_cleans_listener_on_processor_failure(
+        self,
+    ) -> None:
+        """Do not leave an object-queue listener without a processor task."""
+        object_queue = Mock()
+        object_queue.stored = False
+        object_queue.subscribe.return_value = SUB_ID(1)
+        object_queue.unsubscribe = AsyncMock()
+        server = Mock()
+        server.get_oq.return_value = object_queue
+        context = object.__new__(ContextManagerCreateContext)
+        context.master = Mock()
+        context._topic = Mock()
+        processors: List[Any] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        def fail_task_creation(processor: Any) -> None:
+            processors.append(processor)
+            raise RuntimeError("processor startup failed")
+
+        with patch.object(
+            ContextManagerCreateContext,
+            "_get_server",
+            return_value=server,
+        ), patch(
+            "dtps.ergo_create.asyncio.create_task",
+            side_effect=fail_task_creation,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "processor startup failed",
+        ):
+            await context.subscribe(on_data)
+
+        object_queue.unsubscribe.assert_awaited_once_with(SUB_ID(1))
+        self.assertTrue(processors[0].cr_frame is None)

--- a/src/dtps_tests/test_ergo_3_unsubscribe.py
+++ b/src/dtps_tests/test_ergo_3_unsubscribe.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from typing import Any, List
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
@@ -8,6 +9,10 @@ from dtps.ergo_create import (
     ContextManagerCreate,
     ContextManagerCreateContext,
     ContextManagerCreateContextSubscriber,
+)
+from dtps.ergo_use import (
+    ContextManagerUse,
+    ContextManagerUseContextPublisher,
 )
 from dtps_http import async_error_catcher, MIME_TEXT, RawData, SUB_ID
 from dtps_http_tests.utils import test_timeout
@@ -232,3 +237,141 @@ class TestCreateSubscriptionLifecycle(IsolatedAsyncioTestCase):
 
         object_queue.unsubscribe.assert_awaited_once_with(SUB_ID(1))
         self.assertTrue(processors[0].cr_frame is None)
+
+
+class TestUseTaskLifecycle(IsolatedAsyncioTestCase):
+    async def test_remember_task_forgets_completed_task(self) -> None:
+        """Release completed background tasks before manager shutdown."""
+        manager = object.__new__(ContextManagerUse)
+        manager._closing = False
+        manager.tasks = []
+        manager._tasks_lock = threading.Lock()
+
+        async def complete() -> None:
+            return
+
+        task = asyncio.create_task(complete())
+        manager.remember_task(task)
+        await task
+        for _ in range(3):
+            if not manager.tasks:
+                break
+            await asyncio.sleep(0)
+
+        self.assertEqual(manager.tasks, [])
+
+    async def test_remember_task_observes_failures(self) -> None:
+        """Consume a background failure before its task is discarded."""
+        manager = object.__new__(ContextManagerUse)
+        manager._closing = False
+        manager.tasks = []
+        manager._tasks_lock = threading.Lock()
+
+        async def fail() -> None:
+            raise RuntimeError("background task failed")
+
+        with patch("dtps.ergo_use.logger.error") as log_error:
+            task = asyncio.create_task(fail())
+            manager.remember_task(task)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        self.assertEqual(manager.tasks, [])
+        log_error.assert_called_once()
+        self.assertIn(
+            "DTPS background task failed",
+            log_error.call_args.args[0],
+        )
+
+    async def test_task_shutdown_cancels_foreign_loop_task(self) -> None:
+        """Schedule cancellation without awaiting a foreign-loop task."""
+        foreign_loop = Mock()
+        cancel_task = Mock()
+        foreign_task = Mock()
+        foreign_task.cancel = cancel_task
+        foreign_task.get_loop.return_value = foreign_loop
+        manager = object.__new__(ContextManagerUse)
+        manager.tasks = [foreign_task]
+        manager._tasks_lock = threading.Lock()
+
+        await manager._cancel_and_wait_for_tasks()
+
+        foreign_loop.call_soon_threadsafe.assert_called_once_with(cancel_task)
+        cancel_task.assert_not_called()
+        self.assertEqual(manager.tasks, [])
+
+    async def test_remember_task_cancels_late_registration(self) -> None:
+        """Cancel a task registered after use-side shutdown begins."""
+        task_started = asyncio.Event()
+        task_cancelled = asyncio.Event()
+        manager = object.__new__(ContextManagerUse)
+        manager._closing = True
+        manager.tasks = []
+        manager._tasks_lock = threading.Lock()
+
+        async def pending() -> None:
+            task_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                task_cancelled.set()
+                raise
+
+        task = asyncio.create_task(pending())
+        try:
+            await task_started.wait()
+            manager.remember_task(task)
+            await asyncio.wait_for(task_cancelled.wait(), timeout=1)
+            await asyncio.gather(task, return_exceptions=True)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        self.assertTrue(task.done())
+        for _ in range(3):
+            if not manager.tasks:
+                break
+            await asyncio.sleep(0)
+        self.assertEqual(manager.tasks, [])
+
+    async def test_publisher_registers_push_task(self) -> None:
+        """Make the use manager own the persistent publisher task."""
+        client = Mock()
+        manager = Mock()
+        manager.client = client
+        context = Mock()
+        context._get_best_url = AsyncMock(return_value="url")
+
+        async def push() -> None:
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(push())
+        client.push_continuous = AsyncMock(return_value=task)
+        publisher = ContextManagerUseContextPublisher(context, manager)
+        try:
+            await publisher.init()
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        manager.remember_task.assert_called_once_with(task)
+
+    async def test_publisher_terminate_waits_for_task(self) -> None:
+        """Complete persistent-publisher cancellation before returning."""
+        task_started = asyncio.Event()
+
+        async def push() -> None:
+            task_started.set()
+            await asyncio.Event().wait()
+
+        publisher = object.__new__(ContextManagerUseContextPublisher)
+        task = asyncio.create_task(push())
+        publisher.task_push = task
+        try:
+            await task_started.wait()
+            await publisher.terminate()
+            self.assertTrue(task.done())
+            self.assertTrue(task.cancelled())
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)

--- a/src/dtps_tests/test_ergo_3_unsubscribe.py
+++ b/src/dtps_tests/test_ergo_3_unsubscribe.py
@@ -4,7 +4,7 @@ from typing import Any, List
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
-from dtps import DTPSContext
+from dtps import ContextConfig, DTPSContext
 from dtps.ergo_create import (
     ContextManagerCreate,
     ContextManagerCreateContext,
@@ -12,7 +12,9 @@ from dtps.ergo_create import (
 )
 from dtps.ergo_use import (
     ContextManagerUse,
+    ContextManagerUseContext,
     ContextManagerUseContextPublisher,
+    ContextManagerUseSubscription,
 )
 from dtps_http import async_error_catcher, MIME_TEXT, RawData, SUB_ID
 from dtps_http_tests.utils import test_timeout
@@ -333,6 +335,221 @@ class TestUseTaskLifecycle(IsolatedAsyncioTestCase):
                 break
             await asyncio.sleep(0)
         self.assertEqual(manager.tasks, [])
+
+    async def test_use_manager_unsubscribes_tracked_subscriptions(
+        self,
+    ) -> None:
+        """Stop normal subscriptions owned by the use manager."""
+        subscription = Mock()
+        subscription.unsubscribe = AsyncMock()
+        manager = object.__new__(ContextManagerUse)
+        manager._tasks_lock = threading.Lock()
+        manager._subscriptions = {subscription}
+
+        await manager._unsubscribe_subscriptions()
+
+        subscription.unsubscribe.assert_awaited_once()
+        self.assertEqual(manager._subscriptions, set())
+
+    async def test_use_subscription_tracks_processor_task(self) -> None:
+        """Register the callback processor for manager shutdown."""
+        recorded_tasks: List[asyncio.Task[None]] = []
+        listener = Mock()
+        listener.stop = AsyncMock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = Mock()
+        manager.client = client
+        manager.remember_task.side_effect = recorded_tasks.append
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        try:
+            with patch.object(
+                ContextManagerUseContext,
+                "_get_best_url",
+                new=AsyncMock(return_value="url"),
+            ):
+                await context.subscribe_once(on_data)
+            self.assertEqual(len(recorded_tasks), 1)
+            self.assertIsInstance(recorded_tasks[0], asyncio.Task)
+        finally:
+            for processor_task in recorded_tasks:
+                processor_task.cancel()
+            if recorded_tasks:
+                await asyncio.gather(
+                    *recorded_tasks,
+                    return_exceptions=True,
+                )
+
+    async def test_use_subscription_closes_processor_on_task_failure(
+        self,
+    ) -> None:
+        """Close a processor coroutine when its task cannot start."""
+        client = Mock()
+        manager = Mock()
+        manager.client = client
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        processors: List[Any] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        def fail_task_creation(processor: Any) -> None:
+            processors.append(processor)
+            raise RuntimeError("processor startup failed")
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), patch(
+            "dtps.ergo_use.asyncio.create_task",
+            side_effect=fail_task_creation,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "processor startup failed",
+        ):
+            await context.subscribe_once(on_data)
+
+        manager.remember_task.assert_not_called()
+        client.listen_url.assert_not_called()
+        self.assertTrue(processors[0].cr_frame is None)
+
+    async def test_use_subscription_stops_processor_on_unsubscribe(
+        self,
+    ) -> None:
+        """Cancel the normal callback worker on unsubscribe."""
+        processor_started = asyncio.Event()
+        processor_cancelled = asyncio.Event()
+        listener = Mock()
+        listener.stop = AsyncMock()
+
+        async def process() -> None:
+            processor_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                processor_cancelled.set()
+                raise
+
+        processor_task = asyncio.create_task(process())
+        subscription = ContextManagerUseSubscription(
+            listener,
+            processor_task,
+            asyncio.Event(),
+        )
+        try:
+            await processor_started.wait()
+            await subscription.unsubscribe()
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        listener.stop.assert_awaited_once()
+        self.assertTrue(processor_cancelled.is_set())
+        self.assertTrue(processor_task.done())
+
+    async def test_use_callback_can_unsubscribe_itself(self) -> None:
+        """Finish a remote callback that stops its own subscription."""
+        callback_finished = asyncio.Event()
+        listener = Mock()
+        listener.stop = AsyncMock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = Mock()
+        manager.client = client
+        manager.remember_task = Mock()
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        subscription_holder: List[ContextManagerUseSubscription] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            subscription = subscription_holder[0]
+            await subscription.unsubscribe()
+            callback_finished.set()
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ):
+            subscription = await context.subscribe_once(on_data)
+        assert isinstance(subscription, ContextManagerUseSubscription)
+        subscription_holder.append(subscription)
+        wrapped_callback = client.listen_url.call_args.args[1]
+        await wrapped_callback(
+            RawData(content=b"payload", content_type=MIME_TEXT),
+        )
+
+        await asyncio.wait_for(callback_finished.wait(), timeout=1)
+        await asyncio.wait_for(subscription._processor_task, timeout=1)
+
+        listener.stop.assert_awaited_once()
+        self.assertFalse(subscription._processor_task.cancelled())
+
+    async def test_use_subscription_setup_failure_stops_processor(
+        self,
+    ) -> None:
+        """Do not retain a worker when listener setup raises."""
+        recorded_tasks: List[asyncio.Task[None]] = []
+        client = Mock()
+        client.listen_url = AsyncMock(side_effect=RuntimeError("listen failed"))
+        manager = Mock()
+        manager.client = client
+        manager.remember_task.side_effect = recorded_tasks.append
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), self.assertRaisesRegex(RuntimeError, "listen failed"):
+            await context.subscribe_once(on_data)
+
+        self.assertEqual(len(recorded_tasks), 1)
+        processor_task = recorded_tasks[0]
+        self.assertTrue(processor_task.done())
+        self.assertTrue(processor_task.cancelled())
+
+    async def test_use_subscription_rejects_closing_manager(self) -> None:
+        """Do not return a listener created after shutdown starts."""
+        listener = Mock()
+        listener.stop = AsyncMock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = object.__new__(ContextManagerUse)
+        manager._closing = True
+        manager._tasks_lock = threading.Lock()
+        manager.tasks = []
+        manager.client = client
+        manager._subscriptions = set()
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        context.config = ContextConfig.default()
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "Context manager is closing",
+        ):
+            await context.subscribe(on_data)
+
+        listener.stop.assert_awaited_once()
 
     async def test_publisher_registers_push_task(self) -> None:
         """Make the use manager own the persistent publisher task."""

--- a/src/dtps_tests/test_max_frequency.py
+++ b/src/dtps_tests/test_max_frequency.py
@@ -4,6 +4,10 @@ from typing import List
 from unittest import IsolatedAsyncioTestCase
 
 from dtps import DTPSContext
+from dtps.ergo_use import (
+    ContextManagerUseContext,
+    WARN_USE_PUBLISH_CONTEXT_HORIZON_S,
+)
 from dtps_http import (
     async_error_catcher,
     RawData,
@@ -128,6 +132,15 @@ class TestMaxFrequency(IsolatedAsyncioTestCase):
                 self.assertEqual(listener_info.num_listeners, 0)
 
                 self.assertEqual(listener_info.max_frequency, None)
+
+    def test_publishing_frequency_handles_only_stale_history(self) -> None:
+        """Return zero after pruning the last stale publication timestamp."""
+        context = object.__new__(ContextManagerUseContext)
+        context.last_published = [
+            time.time() - WARN_USE_PUBLISH_CONTEXT_HORIZON_S - 1,
+        ]
+
+        self.assertEqual(context._get_frequency_publishing(), 0.0)
 
     @test_timeout(20)
     @async_error_catcher

--- a/src/dtps_tests/test_patient.py
+++ b/src/dtps_tests/test_patient.py
@@ -4,8 +4,10 @@ import tempfile
 from asyncio import Event
 from typing import List
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock
 
 from dtps import ContextConfig, DTPSContext
+from dtps.ergo_use import ContextManagerUseContext, FakeSubscriptionInterface
 from dtps_http import (
     async_error_catcher,
     RawData,
@@ -115,3 +117,110 @@ class TestPatient1(IsolatedAsyncioTestCase):
                 await t
                 logger.info(f"found: {found}")
                 # self.assertEqual(len(found), 2)
+
+
+class TestPatientSubscriptionCleanup(IsolatedAsyncioTestCase):
+    async def test_unsubscribe_closes_late_subscription(self) -> None:
+        """Close a real subscription assigned after the caller unsubscribes."""
+        subscribe_started = asyncio.Event()
+        release_subscription = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscribe_started.set()
+            await release_subscription.wait()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscribe_started.wait()
+            await fldi.unsubscribe()
+            release_subscription.set()
+            await asyncio.wait_for(patient_task, timeout=1)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()
+
+    async def test_task_cancellation_closes_subscription(self) -> None:
+        """Release the active real subscription during manager shutdown."""
+        subscription_assigned = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscription_assigned.set()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscription_assigned.wait()
+            await asyncio.sleep(0)
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()
+
+    async def test_unsubscribe_wakes_active_subscription(self) -> None:
+        """Wake a patient retry worker when its active subscription stops."""
+        subscription_assigned = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscription_assigned.set()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscription_assigned.wait()
+            await asyncio.sleep(0)
+            self.assertIs(fldi.real, real_subscription)
+            await fldi.unsubscribe()
+            await asyncio.wait_for(patient_task, timeout=1)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()

--- a/src/dtps_tests/test_shm.py
+++ b/src/dtps_tests/test_shm.py
@@ -1,0 +1,1943 @@
+"""Integration tests for DTPS shared-memory publish and subscribe options."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import threading
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from unittest import IsolatedAsyncioTestCase, skipUnless
+from unittest.mock import AsyncMock, Mock, patch
+
+from dtps import ContextConfig
+from dtps.ergo_create import (
+    ContextManagerCreate,
+    ContextManagerCreateContext,
+    ContextManagerCreateContextSubscriber,
+)
+from dtps.ergo_use import (
+    ContextManagerUse,
+    ContextManagerUseContext,
+    ContextManagerUseContextPublisher,
+    ContextManagerUseSubscription,
+    FakeSubscriptionInterface,
+)
+from dtps.shm import (
+    ShmWriterPool,
+    _ShmSubscription,
+    _ShmWriterEntry,
+    create_shm_subscription,
+    should_publish_http,
+)
+from dtps_http import MIME_TEXT, RawData, SUB_ID
+from dtps_http_tests.utils import test_timeout
+
+from .utils import create_use, create_use_pair
+
+fcntl: Any = None
+with suppress(ImportError):
+    import fcntl
+
+_REQUIRED_FCNTL_CAPABILITIES = (
+    "flock",
+    "LOCK_EX",
+    "LOCK_SH",
+    "LOCK_UN",
+)
+_REQUIRED_OS_CAPABILITIES = (
+    "O_CLOEXEC",
+    "O_NOFOLLOW",
+    "O_NONBLOCK",
+    "chmod",
+    "fchmod",
+    "ftruncate",
+    "geteuid",
+    "mkfifo",
+    "pread",
+    "pwrite",
+)
+
+
+def _has_required_capabilities(
+    module: object,
+    capabilities: tuple[str, ...],
+) -> bool:
+    """Return whether *module* provides every named capability."""
+    for capability in capabilities:
+        if getattr(module, capability, None) is None:
+            return False
+    return True
+
+
+_SHM_TEST_SUPPORTED = (
+    os.name == "posix"
+    and fcntl is not None
+    and _has_required_capabilities(
+        fcntl,
+        _REQUIRED_FCNTL_CAPABILITIES,
+    )
+    and _has_required_capabilities(os, _REQUIRED_OS_CAPABILITIES)
+)
+_THREAD_TIMEOUT_SECONDS = 5
+
+
+class _BlockingWriter:
+    """Test double that records whether shutdown overlaps publication."""
+
+    def __init__(self) -> None:
+        """Initialize synchronization state for one artificial publication."""
+        self.close_called = threading.Event()
+        self.publish_started = threading.Event()
+        self.release_publish = threading.Event()
+        self._publishing = False
+        self._state_lock = threading.Lock()
+        self.close_called_during_publish = False
+
+    def publish(self, _payload: bytes) -> None:
+        """Block publication until the test permits it to finish."""
+        with self._state_lock:
+            self._publishing = True
+        self.publish_started.set()
+        self.release_publish.wait()
+        with self._state_lock:
+            self._publishing = False
+
+    def close(self) -> None:
+        """Record whether close began while publication was active."""
+        with self._state_lock:
+            self.close_called_during_publish = self._publishing
+        self.close_called.set()
+
+
+class _FailingWriter:
+    """Test double that checks whether failure cleanup holds its entry lock."""
+
+    def __init__(self) -> None:
+        """Initialize state for one failed publication."""
+        self.entry_lock: Any = None
+        self.entry_lock_held_on_close: bool | None = None
+        self.close_called = False
+
+    def publish(self, _payload: bytes) -> None:
+        """Fail publication to exercise cleanup."""
+        error_message = "publish failed"
+        raise RuntimeError(error_message)
+
+    def close(self) -> None:
+        """Record whether the pool holds the entry lock while closing."""
+        entry_lock = self.entry_lock
+        if entry_lock is None:
+            error_message = "Entry lock was not configured."
+            raise AssertionError(error_message)
+        self.entry_lock_held_on_close = entry_lock.locked()
+        self.close_called = True
+
+
+@skipUnless(
+    _SHM_TEST_SUPPORTED,
+    "Shared-memory transport tests require POSIX capabilities.",
+)
+class TestHttpSharedMemoryTransport(IsolatedAsyncioTestCase):
+    """Verify HTTP delivery can mirror and exclusively use local SHM channels."""
+
+    def test_writer_pool_closes_failed_writer_under_entry_lock(
+        self,
+    ) -> None:
+        """Close a failed writer while holding its lifecycle lock."""
+        writer_pool = ShmWriterPool()
+        failing_writer = _FailingWriter()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        shm_path = "channel"
+
+        with patch(
+            "dtps.shm.ShmWriter",
+            return_value=failing_writer,
+        ):
+            writer_entry = writer_pool._get_writer_entry(shm_path)
+            if writer_entry is None:
+                self.fail("Writer pool did not create an entry.")
+            failing_writer.entry_lock = writer_entry.lock
+            published = writer_pool.publish(raw_data, shm_path)
+
+        self.assertFalse(published)
+        self.assertTrue(failing_writer.close_called)
+        self.assertTrue(failing_writer.entry_lock_held_on_close)
+        self.assertNotIn(shm_path, writer_pool._writers)
+
+    def test_writer_pool_logs_publish_and_cleanup_failures(self) -> None:
+        """Retain the publish failure when writer cleanup also fails."""
+        writer_pool = ShmWriterPool()
+        failing_writer = Mock()
+        publish_error = RuntimeError("publish failed")
+        cleanup_error = RuntimeError("cleanup failed")
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        shm_path = "channel"
+        failing_writer.publish.side_effect = publish_error
+        failing_writer.close.side_effect = cleanup_error
+
+        with patch(
+            "dtps.shm.ShmWriter",
+            return_value=failing_writer,
+        ), patch("dtps.shm.logger.warning") as log_warning:
+            published = writer_pool.publish(raw_data, shm_path)
+
+        self.assertFalse(published)
+        warning_message, *warning_arguments = log_warning.call_args.args
+        self.assertIn("writer cleanup also failed", warning_message)
+        self.assertIn("falling back to normal DTPS delivery", warning_message)
+        self.assertEqual(
+            warning_arguments,
+            [shm_path, publish_error, cleanup_error],
+        )
+
+    def test_writer_pool_serializes_publish_and_close(self) -> None:
+        """Wait for an in-flight SHM publish before closing its writer."""
+        writer_pool = ShmWriterPool()
+        blocking_writer = _BlockingWriter()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        shm_path = "channel"
+        close_entry_attempted = threading.Event()
+        original_close_writer_entry = writer_pool._close_writer_entry
+
+        def record_close_entry_attempt(
+            writer_entry: _ShmWriterEntry,
+        ) -> None:
+            close_entry_attempted.set()
+            original_close_writer_entry(writer_entry)
+
+        with patch(
+            "dtps.shm.ShmWriter",
+            return_value=blocking_writer,
+        ), patch.object(
+            writer_pool,
+            "_close_writer_entry",
+            side_effect=record_close_entry_attempt,
+        ):
+            publish_thread = threading.Thread(
+                target=writer_pool.publish,
+                args=(raw_data, shm_path),
+            )
+            close_thread = threading.Thread(target=writer_pool.close)
+            publish_thread.start()
+            try:
+                publish_started = blocking_writer.publish_started.wait(
+                    _THREAD_TIMEOUT_SECONDS,
+                )
+                self.assertTrue(publish_started)
+                close_thread.start()
+                close_attempt_started = close_entry_attempted.wait(
+                    _THREAD_TIMEOUT_SECONDS,
+                )
+                self.assertTrue(close_attempt_started)
+                self.assertFalse(blocking_writer.close_called.is_set())
+            finally:
+                blocking_writer.release_publish.set()
+                publish_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+                close_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+
+        publish_thread_alive = publish_thread.is_alive()
+        close_thread_alive = close_thread.is_alive()
+        close_called = blocking_writer.close_called.is_set()
+        self.assertFalse(blocking_writer.close_called_during_publish)
+        self.assertTrue(close_called)
+        self.assertFalse(publish_thread_alive)
+        self.assertFalse(close_thread_alive)
+
+    def test_writer_pool_waits_for_failed_publish_cleanup(self) -> None:
+        """Keep a failed writer registered until its close has completed."""
+        writer_pool = ShmWriterPool()
+        failing_writer = Mock()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        close_started = threading.Event()
+        allow_close = threading.Event()
+        close_attempted = threading.Event()
+        close_completed = threading.Event()
+        original_close_writer_entry = writer_pool._close_writer_entry
+
+        def fail_publish(_payload: bytes) -> None:
+            raise RuntimeError("publish failed")
+
+        def block_close() -> None:
+            close_started.set()
+            allow_close.wait()
+
+        def record_close_attempt(writer_entry: _ShmWriterEntry) -> None:
+            close_attempted.set()
+            original_close_writer_entry(writer_entry)
+
+        def close_pool() -> None:
+            writer_pool.close()
+            close_completed.set()
+
+        failing_writer.publish.side_effect = fail_publish
+        failing_writer.close.side_effect = block_close
+        with patch(
+            "dtps.shm.ShmWriter",
+            return_value=failing_writer,
+        ), patch.object(
+            writer_pool,
+            "_close_writer_entry",
+            side_effect=record_close_attempt,
+        ):
+            publish_thread = threading.Thread(
+                target=writer_pool.publish,
+                args=(raw_data, "channel"),
+            )
+            close_thread = threading.Thread(target=close_pool)
+            publish_thread.start()
+            try:
+                self.assertTrue(
+                    close_started.wait(_THREAD_TIMEOUT_SECONDS),
+                )
+                close_thread.start()
+                self.assertTrue(
+                    close_attempted.wait(_THREAD_TIMEOUT_SECONDS),
+                )
+                self.assertFalse(close_completed.is_set())
+            finally:
+                allow_close.set()
+                publish_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+                close_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+
+        self.assertFalse(publish_thread.is_alive())
+        self.assertFalse(close_thread.is_alive())
+        self.assertTrue(close_completed.is_set())
+        failing_writer.close.assert_called_once()
+
+    def test_writer_pool_allows_distinct_channel_publishes(self) -> None:
+        """Do not block one channel's publication behind another channel."""
+        writer_pool = ShmWriterPool()
+        blocking_writer = _BlockingWriter()
+        second_writer = Mock()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        second_publish_completed = threading.Event()
+
+        def publish_second_channel() -> None:
+            writer_pool.publish(raw_data, "second-channel")
+            second_publish_completed.set()
+
+        second_writer.publish.side_effect = lambda _payload: None
+        with patch(
+            "dtps.shm.ShmWriter",
+            side_effect=[blocking_writer, second_writer],
+        ):
+            first_publish_thread = threading.Thread(
+                target=writer_pool.publish,
+                args=(raw_data, "first-channel"),
+            )
+            second_publish_thread = threading.Thread(
+                target=publish_second_channel,
+            )
+            first_publish_thread.start()
+            try:
+                first_publish_started = blocking_writer.publish_started.wait(
+                    _THREAD_TIMEOUT_SECONDS,
+                )
+                self.assertTrue(first_publish_started)
+                second_publish_thread.start()
+                second_publish_completed_early = (
+                    second_publish_completed.wait(_THREAD_TIMEOUT_SECONDS)
+                )
+            finally:
+                blocking_writer.release_publish.set()
+                first_publish_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+                second_publish_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+                writer_pool.close()
+
+        self.assertTrue(second_publish_completed_early)
+        self.assertFalse(first_publish_thread.is_alive())
+        self.assertFalse(second_publish_thread.is_alive())
+        second_writer.publish.assert_called_once()
+
+    def test_writer_pool_does_not_reopen_after_close(self) -> None:
+        """Do not create a replacement writer after terminal shutdown."""
+        writer_pool = ShmWriterPool()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+
+        writer_pool.close()
+        with patch("dtps.shm.ShmWriter") as writer_type:
+            published = writer_pool.publish(raw_data, "channel")
+
+        self.assertFalse(published)
+        writer_type.assert_not_called()
+
+    async def test_create_close_stops_server_after_writer_close_failure(
+        self,
+    ) -> None:
+        """Close the server even when SHM writer cleanup raises."""
+        writer_pool = Mock()
+        server_wrap = Mock()
+        writer_pool.close.side_effect = RuntimeError("writer close failed")
+        server_wrap.aclose = AsyncMock()
+        context_manager = object.__new__(ContextManagerCreate)
+        context_manager._shm_writers = writer_pool
+        context_manager.dtps_server_wrap = server_wrap
+        context_manager._subscriptions = set()
+        context_manager._closing = False
+
+        with self.assertRaisesRegex(RuntimeError, "writer close failed"):
+            await context_manager.aclose()
+
+        server_wrap.aclose.assert_awaited_once()
+
+    async def test_create_close_stops_registered_subscriptions(self) -> None:
+        """Stop active subscriptions before closing create-side resources."""
+        close_events: list[str] = []
+        subscription = Mock()
+        writer_pool = Mock()
+        server_wrap = Mock()
+
+        async def stop_subscription() -> None:
+            close_events.append("subscription")
+
+        def close_writers() -> None:
+            close_events.append("writers")
+
+        async def close_server() -> None:
+            close_events.append("server")
+
+        subscription.unsubscribe = AsyncMock(side_effect=stop_subscription)
+        writer_pool.close.side_effect = close_writers
+        server_wrap.aclose = AsyncMock(side_effect=close_server)
+        context_manager = object.__new__(ContextManagerCreate)
+        context_manager._shm_writers = writer_pool
+        context_manager.dtps_server_wrap = server_wrap
+        context_manager._subscriptions = {subscription}
+        context_manager._closing = False
+
+        await context_manager.aclose()
+
+        subscription.unsubscribe.assert_awaited_once()
+        self.assertEqual(close_events, ["subscription", "writers", "server"])
+
+    async def test_create_subscription_stops_its_processor(self) -> None:
+        """Cancel and await a create-side callback worker on unsubscribe."""
+        processor_started = asyncio.Event()
+        processor_cancelled = asyncio.Event()
+        object_queue = Mock()
+        object_queue.unsubscribe = AsyncMock()
+        manager = Mock()
+
+        async def process() -> None:
+            processor_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                processor_cancelled.set()
+                raise
+
+        processor_task = asyncio.create_task(process())
+        subscription_id = SUB_ID(1)
+        subscription = ContextManagerCreateContextSubscriber(
+            manager,
+            subscription_id,
+            object_queue,
+            processor_task,
+            asyncio.Event(),
+        )
+        try:
+            await processor_started.wait()
+            await subscription.unsubscribe()
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        object_queue.unsubscribe.assert_awaited_once_with(subscription_id)
+        manager.forget_subscription.assert_called_once_with(subscription)
+        self.assertTrue(processor_cancelled.is_set())
+        self.assertTrue(processor_task.done())
+
+    async def test_create_callback_can_unsubscribe_itself(self) -> None:
+        """Finish a create-side callback that stops its own subscription."""
+        callback_finished = asyncio.Event()
+        object_queue = Mock()
+        object_queue.stored = False
+        object_queue.unsubscribe = AsyncMock()
+        captured_callbacks: list[Any] = []
+
+        def capture_callback(
+            callback: object,
+            **_kwargs: object,
+        ) -> SUB_ID:
+            captured_callbacks.append(callback)
+            return SUB_ID(1)
+
+        object_queue.subscribe.side_effect = capture_callback
+        server = Mock()
+        server.get_oq.return_value = object_queue
+        manager = Mock()
+        manager.remember_subscription = AsyncMock()
+        context = object.__new__(ContextManagerCreateContext)
+        context.master = manager
+        context._topic = Mock()
+        subscription_holder: list[ContextManagerCreateContextSubscriber] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            subscription = subscription_holder[0]
+            await subscription.unsubscribe()
+            callback_finished.set()
+
+        with patch.object(
+            ContextManagerCreateContext,
+            "_get_server",
+            return_value=server,
+        ):
+            subscription = await context.subscribe(on_data)
+        assert isinstance(
+            subscription,
+            ContextManagerCreateContextSubscriber,
+        )
+        subscription_holder.append(subscription)
+        wrapped_callback = captured_callbacks[0]
+        notification = Mock()
+        notification.raw_data = RawData(
+            content=b"payload",
+            content_type=MIME_TEXT,
+        )
+        await wrapped_callback(object_queue, notification)
+
+        await asyncio.wait_for(callback_finished.wait(), timeout=1)
+        await asyncio.wait_for(subscription._processor_task, timeout=1)
+
+        object_queue.unsubscribe.assert_awaited_once_with(subscription.sub_id)
+        manager.forget_subscription.assert_called_once_with(subscription)
+        self.assertFalse(subscription._processor_task.cancelled())
+
+    async def test_create_subscribe_cleans_listener_on_processor_failure(
+        self,
+    ) -> None:
+        """Do not leave an object-queue listener without a processor task."""
+        object_queue = Mock()
+        object_queue.stored = False
+        object_queue.subscribe.return_value = SUB_ID(1)
+        object_queue.unsubscribe = AsyncMock()
+        server = Mock()
+        server.get_oq.return_value = object_queue
+        context = object.__new__(ContextManagerCreateContext)
+        context.master = Mock()
+        context._topic = Mock()
+        processors: list[Any] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        def fail_task_creation(processor: Any) -> None:
+            processors.append(processor)
+            raise RuntimeError("processor startup failed")
+
+        with patch.object(
+            ContextManagerCreateContext,
+            "_get_server",
+            return_value=server,
+        ), patch(
+            "dtps.ergo_create.asyncio.create_task",
+            side_effect=fail_task_creation,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "processor startup failed",
+        ):
+            await context.subscribe(on_data)
+
+        object_queue.unsubscribe.assert_awaited_once_with(SUB_ID(1))
+        self.assertTrue(processors[0].cr_frame is None)
+
+    async def test_create_shm_subscription_is_registered_for_shutdown(
+        self,
+    ) -> None:
+        """Register an SHM-only subscription with the create manager."""
+        manager = Mock()
+        manager.remember_subscription = AsyncMock()
+        subscription = Mock()
+        context = object.__new__(ContextManagerCreateContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with patch(
+            "dtps.ergo_create.create_shm_subscription",
+            return_value=subscription,
+        ) as create_subscription:
+            result = await context.subscribe(
+                on_data,
+                max_frequency=13.0,
+                shm_path="channel",
+                shm_only=True,
+            )
+
+        self.assertIs(result, subscription)
+        manager.remember_subscription.assert_awaited_once_with(subscription)
+        self.assertIs(
+            create_subscription.call_args.kwargs["on_unsubscribe"],
+            manager.forget_subscription,
+        )
+        self.assertEqual(
+            create_subscription.call_args.kwargs["max_frequency"],
+            13.0,
+        )
+
+    async def test_use_close_waits_for_tasks_before_writers(self) -> None:
+        """Let canceled publisher tasks finish before closing SHM writers."""
+        close_events: list[str] = []
+        task_started = asyncio.Event()
+        task_wait_event = asyncio.Event()
+        writer_pool = Mock()
+        client = Mock()
+
+        def close_writers() -> None:
+            close_events.append("writers")
+
+        async def publishing_task() -> None:
+            task_started.set()
+            try:
+                await task_wait_event.wait()
+            except asyncio.CancelledError:
+                close_events.append("task")
+                raise
+
+        writer_pool.close.side_effect = close_writers
+        client.aclose = AsyncMock()
+        task = asyncio.create_task(publishing_task())
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._shm_writers = writer_pool
+        context_manager.client = client
+        context_manager.tasks = [task]
+        context_manager._tasks_lock = threading.Lock()
+        context_manager._subscriptions = set()
+        context_manager._shm_subscriptions = set()
+
+        try:
+            await task_started.wait()
+            await context_manager.aclose()
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        self.assertEqual(close_events, ["task", "writers"])
+        client.aclose.assert_awaited_once()
+
+    async def test_use_close_waits_for_tasks_added_from_other_thread(
+        self,
+    ) -> None:
+        """Await tasks registered from another thread during shutdown."""
+        close_events: list[str] = []
+        late_task_started = asyncio.Event()
+        late_tasks: list[asyncio.Task[None]] = []
+        registration_threads: list[threading.Thread] = []
+        writer_pool = Mock()
+        client = Mock()
+
+        def close_writers() -> None:
+            close_events.append("writers")
+
+        async def late_task() -> None:
+            late_task_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                close_events.append("task")
+                raise
+
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._shm_writers = writer_pool
+        context_manager.client = client
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        context_manager._subscriptions = set()
+        context_manager._shm_subscriptions = set()
+
+        async def close_client() -> None:
+            task = asyncio.create_task(late_task())
+            late_tasks.append(task)
+            await late_task_started.wait()
+            registration_thread = threading.Thread(
+                target=context_manager.remember_task,
+                args=(task,),
+            )
+            registration_threads.append(registration_thread)
+            registration_thread.start()
+            registration_thread.join(timeout=_THREAD_TIMEOUT_SECONDS)
+
+        writer_pool.close.side_effect = close_writers
+        client.aclose = AsyncMock(side_effect=close_client)
+        try:
+            await context_manager.aclose()
+        finally:
+            for task in late_tasks:
+                task.cancel()
+            if late_tasks:
+                await asyncio.gather(*late_tasks, return_exceptions=True)
+
+        self.assertFalse(registration_threads[0].is_alive())
+        self.assertEqual(close_events, ["task", "writers"])
+        client.aclose.assert_awaited_once()
+
+    async def test_use_close_stops_registered_shm_subscriptions(self) -> None:
+        """Stop SHM readers before the use-side client and writers close."""
+        close_events: list[str] = []
+        subscription = Mock()
+        writer_pool = Mock()
+        client = Mock()
+        context_manager = object.__new__(ContextManagerUse)
+
+        async def stop_subscription() -> None:
+            close_events.append("subscription")
+
+        async def close_client() -> None:
+            close_events.append("client")
+
+        def close_writers() -> None:
+            close_events.append("writers")
+
+        subscription.unsubscribe = AsyncMock(side_effect=stop_subscription)
+        client.aclose = AsyncMock(side_effect=close_client)
+        writer_pool.close.side_effect = close_writers
+        context_manager._closing = False
+        context_manager._shm_writers = writer_pool
+        context_manager.client = client
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        context_manager._subscriptions = set()
+        context_manager._shm_subscriptions = {subscription}
+
+        await context_manager.aclose()
+
+        subscription.unsubscribe.assert_awaited_once()
+        self.assertEqual(close_events, ["subscription", "client", "writers"])
+
+    async def test_use_close_stops_registered_normal_subscriptions(
+        self,
+    ) -> None:
+        """Stop normal listeners before closing use-side client resources."""
+        close_events: list[str] = []
+        subscription = Mock()
+        writer_pool = Mock()
+        client = Mock()
+        context_manager = object.__new__(ContextManagerUse)
+
+        async def stop_subscription() -> None:
+            close_events.append("subscription")
+
+        async def close_client() -> None:
+            close_events.append("client")
+
+        def close_writers() -> None:
+            close_events.append("writers")
+
+        subscription.unsubscribe = AsyncMock(side_effect=stop_subscription)
+        client.aclose = AsyncMock(side_effect=close_client)
+        writer_pool.close.side_effect = close_writers
+        context_manager._closing = False
+        context_manager._shm_writers = writer_pool
+        context_manager.client = client
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        context_manager._subscriptions = {subscription}
+        context_manager._shm_subscriptions = set()
+
+        await context_manager.aclose()
+
+        subscription.unsubscribe.assert_awaited_once()
+        self.assertEqual(close_events, ["subscription", "client", "writers"])
+
+    def test_remember_task_ignores_closed_task_loop(self) -> None:
+        """Keep late shutdown registration harmless after a loop closes."""
+        task_loop = Mock()
+        cancel_task = Mock()
+        task = Mock()
+        task.get_loop.return_value = task_loop
+        task.cancel = cancel_task
+        task_loop.call_soon_threadsafe.side_effect = RuntimeError(
+            "Event loop is closed",
+        )
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._closing = True
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+
+        context_manager.remember_task(task)
+
+        self.assertEqual(context_manager.tasks, [task])
+        task_loop.call_soon_threadsafe.assert_any_call(
+            task.add_done_callback,
+            context_manager._handle_task_completion,
+        )
+        task_loop.call_soon_threadsafe.assert_any_call(cancel_task)
+        self.assertEqual(task_loop.call_soon_threadsafe.call_count, 2)
+        cancel_task.assert_not_called()
+
+    async def test_remember_task_forgets_completed_task(self) -> None:
+        """Release completed publisher and callback tasks before shutdown."""
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._closing = False
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+
+        async def complete() -> None:
+            return
+
+        task = asyncio.create_task(complete())
+        context_manager.remember_task(task)
+        await task
+        for _ in range(3):
+            if not context_manager.tasks:
+                break
+            await asyncio.sleep(0)
+
+        self.assertEqual(context_manager.tasks, [])
+
+    async def test_remember_task_consumes_failed_task_exception(self) -> None:
+        """Avoid an unhandled-task report when a background task fails."""
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._closing = False
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        loop = asyncio.get_running_loop()
+        unhandled_contexts: list[dict[str, object]] = []
+        previous_exception_handler = loop.get_exception_handler()
+
+        async def fail() -> None:
+            raise RuntimeError("background task failed")
+
+        loop.set_exception_handler(
+            lambda _loop, context: unhandled_contexts.append(context),
+        )
+        try:
+            with patch("dtps.ergo_use.logger.error") as log_error:
+                task = asyncio.create_task(fail())
+                context_manager.remember_task(task)
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                del task
+                await asyncio.sleep(0)
+
+            self.assertEqual(context_manager.tasks, [])
+            self.assertEqual(unhandled_contexts, [])
+            log_error.assert_called_once()
+            self.assertIn(
+                "DTPS background task failed",
+                log_error.call_args.args[0],
+            )
+        finally:
+            loop.set_exception_handler(previous_exception_handler)
+
+    async def test_remember_late_task_consumes_cancellation_failure(
+        self,
+    ) -> None:
+        """Observe a task registered after the use manager starts closing."""
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._closing = True
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        loop = asyncio.get_running_loop()
+        unhandled_contexts: list[dict[str, object]] = []
+        previous_exception_handler = loop.get_exception_handler()
+
+        async def fail_after_cancellation() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("late task failed during cancellation")
+
+        loop.set_exception_handler(
+            lambda _loop, context: unhandled_contexts.append(context),
+        )
+        try:
+            with patch("dtps.ergo_use.logger.error") as log_error:
+                task = asyncio.create_task(fail_after_cancellation())
+                context_manager.remember_task(task)
+                for _ in range(3):
+                    if not context_manager.tasks:
+                        break
+                    await asyncio.sleep(0)
+
+            self.assertTrue(task.done())
+            self.assertEqual(context_manager.tasks, [])
+            self.assertEqual(unhandled_contexts, [])
+            log_error.assert_called_once()
+            self.assertIn(
+                "DTPS background task failed",
+                log_error.call_args.args[0],
+            )
+        finally:
+            loop.set_exception_handler(previous_exception_handler)
+
+    async def test_task_shutdown_schedules_foreign_loop_cancellation(
+        self,
+    ) -> None:
+        """Cancel a foreign-loop task without awaiting it on this loop."""
+        foreign_loop = Mock()
+        cancel_task = Mock()
+        foreign_task = Mock()
+        foreign_task.cancel = cancel_task
+        foreign_task.get_loop.return_value = foreign_loop
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager.tasks = [foreign_task]
+        context_manager._tasks_lock = threading.Lock()
+
+        await context_manager._cancel_and_wait_for_tasks()
+
+        foreign_loop.call_soon_threadsafe.assert_called_once_with(cancel_task)
+        cancel_task.assert_not_called()
+        self.assertEqual(context_manager.tasks, [])
+
+    async def test_use_publisher_task_is_awaited_during_shutdown(
+        self,
+    ) -> None:
+        """Cancel and await a continuous publisher before closing its client."""
+        task_started = asyncio.Event()
+        task_cancelled = asyncio.Event()
+        writer_pool = Mock()
+        client = Mock()
+        context_manager = object.__new__(ContextManagerUse)
+        context_manager._closing = False
+        context_manager._shm_writers = writer_pool
+        context_manager.client = client
+        context_manager.tasks = []
+        context_manager._tasks_lock = threading.Lock()
+        context_manager._subscriptions = set()
+        context_manager._shm_subscriptions = set()
+
+        async def pushing_task() -> None:
+            task_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                task_cancelled.set()
+                raise
+
+        task = asyncio.create_task(pushing_task())
+        client.aclose = AsyncMock()
+        client.push_continuous = AsyncMock(return_value=task)
+        context = Mock()
+        context._get_best_url = AsyncMock(return_value="url")
+        publisher = ContextManagerUseContextPublisher(
+            context,
+            context_manager,
+        )
+
+        try:
+            await publisher.init()
+            await task_started.wait()
+            await context_manager.aclose()
+            self.assertTrue(task_cancelled.is_set())
+            self.assertTrue(task.done())
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        client.aclose.assert_awaited_once()
+
+    async def test_use_publisher_terminate_waits_for_task(self) -> None:
+        """Complete continuous publisher cancellation before returning."""
+        task_started = asyncio.Event()
+
+        async def pushing_task() -> None:
+            task_started.set()
+            await asyncio.Event().wait()
+
+        publisher = object.__new__(ContextManagerUseContextPublisher)
+        task = asyncio.create_task(pushing_task())
+        publisher.task_push = task
+        try:
+            await task_started.wait()
+            await publisher.terminate()
+            self.assertTrue(task.done())
+            self.assertTrue(task.cancelled())
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def test_use_subscription_tracks_processor_task(self) -> None:
+        """Register the callback processor for manager shutdown."""
+        recorded_tasks: list[asyncio.Task[None]] = []
+        listener = Mock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = Mock()
+        manager.client = client
+        manager.remember_task.side_effect = recorded_tasks.append
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        try:
+            with patch.object(
+                ContextManagerUseContext,
+                "_get_best_url",
+                new=AsyncMock(return_value="url"),
+            ):
+                await context.subscribe_once(on_data)
+            self.assertEqual(len(recorded_tasks), 1)
+            processor_task = recorded_tasks[0]
+            self.assertIsInstance(processor_task, asyncio.Task)
+        finally:
+            for processor_task in recorded_tasks:
+                processor_task.cancel()
+            if recorded_tasks:
+                await asyncio.gather(
+                    *recorded_tasks,
+                    return_exceptions=True,
+                )
+
+    async def test_use_subscription_closes_processor_on_task_failure(
+        self,
+    ) -> None:
+        """Do not leak a processor coroutine when task creation raises."""
+        client = Mock()
+        manager = Mock()
+        manager.client = client
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        processors: list[Any] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        def fail_task_creation(processor: Any) -> None:
+            processors.append(processor)
+            raise RuntimeError("processor startup failed")
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), patch(
+            "dtps.ergo_use.asyncio.create_task",
+            side_effect=fail_task_creation,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "processor startup failed",
+        ):
+            await context.subscribe_once(on_data)
+
+        manager.remember_task.assert_not_called()
+        client.listen_url.assert_not_called()
+        self.assertTrue(processors[0].cr_frame is None)
+
+    async def test_use_subscription_stops_processor_on_unsubscribe(
+        self,
+    ) -> None:
+        """Cancel the normal delivery callback worker on unsubscribe."""
+        processor_started = asyncio.Event()
+        processor_cancelled = asyncio.Event()
+        listener = Mock()
+        listener.stop = AsyncMock()
+
+        async def process() -> None:
+            processor_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                processor_cancelled.set()
+                raise
+
+        processor_task = asyncio.create_task(process())
+        subscription = ContextManagerUseSubscription(
+            listener,
+            processor_task,
+            asyncio.Event(),
+        )
+        try:
+            await processor_started.wait()
+            await subscription.unsubscribe()
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        listener.stop.assert_awaited_once()
+        self.assertTrue(processor_cancelled.is_set())
+        self.assertTrue(processor_task.done())
+
+    async def test_use_callback_can_unsubscribe_itself(self) -> None:
+        """Finish a remote callback that stops its own subscription."""
+        callback_finished = asyncio.Event()
+        listener = Mock()
+        listener.stop = AsyncMock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = Mock()
+        manager.client = client
+        manager.remember_task = Mock()
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        subscription_holder: list[ContextManagerUseSubscription] = []
+
+        async def on_data(_raw_data: RawData) -> None:
+            subscription = subscription_holder[0]
+            await subscription.unsubscribe()
+            callback_finished.set()
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ):
+            subscription = await context.subscribe_once(on_data)
+        assert isinstance(subscription, ContextManagerUseSubscription)
+        subscription_holder.append(subscription)
+        wrapped_callback = client.listen_url.call_args.args[1]
+        await wrapped_callback(
+            RawData(content=b"payload", content_type=MIME_TEXT),
+        )
+
+        await asyncio.wait_for(callback_finished.wait(), timeout=1)
+        await asyncio.wait_for(subscription._processor_task, timeout=1)
+
+        listener.stop.assert_awaited_once()
+        self.assertFalse(subscription._processor_task.cancelled())
+
+    async def test_use_subscription_setup_failure_stops_processor(
+        self,
+    ) -> None:
+        """Do not retain a callback worker when listener setup raises."""
+        recorded_tasks: list[asyncio.Task[None]] = []
+        client = Mock()
+        client.listen_url = AsyncMock(side_effect=RuntimeError("listen failed"))
+        manager = Mock()
+        manager.client = client
+        manager.remember_task.side_effect = recorded_tasks.append
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), self.assertRaisesRegex(RuntimeError, "listen failed"):
+            await context.subscribe_once(on_data)
+
+        self.assertEqual(len(recorded_tasks), 1)
+        processor_task = recorded_tasks[0]
+        self.assertTrue(processor_task.done())
+        self.assertTrue(processor_task.cancelled())
+
+    async def test_use_subscription_rejects_closing_manager(self) -> None:
+        """Do not return a listener created after manager shutdown starts."""
+        listener = Mock()
+        listener.stop = AsyncMock()
+        client = Mock()
+        client.listen_url = AsyncMock(return_value=listener)
+        manager = object.__new__(ContextManagerUse)
+        manager._closing = True
+        manager._tasks_lock = threading.Lock()
+        manager.tasks = []
+        manager.client = client
+        manager._subscriptions = set()
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+        context.config = ContextConfig.default()
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        with patch.object(
+            ContextManagerUseContext,
+            "_get_best_url",
+            new=AsyncMock(return_value="url"),
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "Context manager is closing",
+        ):
+            await context.subscribe(on_data)
+
+        listener.stop.assert_awaited_once()
+
+    async def test_use_shm_subscription_is_registered_for_shutdown(
+        self,
+    ) -> None:
+        """Register an SHM-only subscription with the use manager."""
+        manager = Mock()
+        manager.remember_shm_subscription = AsyncMock()
+        subscription = Mock()
+        context = object.__new__(ContextManagerUseContext)
+        context.master = manager
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with patch(
+            "dtps.ergo_use.create_shm_subscription",
+            return_value=subscription,
+        ) as create_subscription:
+            result = await context.subscribe(
+                on_data,
+                max_frequency=13.0,
+                shm_path="channel",
+                shm_only=True,
+            )
+
+        self.assertIs(result, subscription)
+        manager.remember_shm_subscription.assert_awaited_once_with(
+            subscription,
+        )
+        self.assertIs(
+            create_subscription.call_args.kwargs["on_unsubscribe"],
+            manager.forget_shm_subscription,
+        )
+        self.assertEqual(
+            create_subscription.call_args.kwargs["max_frequency"],
+            13.0,
+        )
+
+    async def test_patient_unsubscribe_closes_late_subscription(self) -> None:
+        """Close a real subscription assigned after the caller stops waiting."""
+        subscribe_started = asyncio.Event()
+        release_subscription = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscribe_started.set()
+            await release_subscription.wait()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscribe_started.wait()
+            await fldi.unsubscribe()
+            release_subscription.set()
+            await asyncio.wait_for(patient_task, timeout=1)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()
+
+    async def test_patient_task_cancellation_closes_subscription(self) -> None:
+        """Release the active real subscription during manager shutdown."""
+        subscription_assigned = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscription_assigned.set()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscription_assigned.wait()
+            await asyncio.sleep(0)
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()
+
+    async def test_patient_unsubscribe_wakes_active_subscription(self) -> None:
+        """Wake a patient retry worker when its active subscription stops."""
+        subscription_assigned = asyncio.Event()
+        real_subscription = Mock()
+        real_subscription.unsubscribe = AsyncMock()
+        fldi = FakeSubscriptionInterface(asyncio.Event())
+        context = object.__new__(ContextManagerUseContext)
+
+        async def subscribe_once(
+            *_args: object,
+            **_kwargs: object,
+        ) -> object:
+            subscription_assigned.set()
+            return real_subscription
+
+        setattr(context, "subscribe_once", subscribe_once)
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        patient_task = asyncio.create_task(
+            context._subscribe_patient_task(fldi, on_data),
+        )
+        try:
+            await subscription_assigned.wait()
+            await asyncio.sleep(0)
+            self.assertIs(fldi.real, real_subscription)
+            await fldi.unsubscribe()
+            await asyncio.wait_for(patient_task, timeout=1)
+        finally:
+            patient_task.cancel()
+            await asyncio.gather(patient_task, return_exceptions=True)
+
+        real_subscription.unsubscribe.assert_awaited_once()
+
+    def test_shm_publish_http_decision(self) -> None:
+        """Select HTTP delivery consistently for every SHM publish outcome."""
+        writer_pool = ShmWriterPool()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+
+        with tempfile.TemporaryDirectory() as directory:
+            mirrored_path = Path(directory) / "mirrored"
+            invalid_path = Path(directory) / "invalid"
+            invalid_signal_name = f"{invalid_path.name}.p2c"
+            invalid_signal_path = invalid_path.parent / invalid_signal_name
+            invalid_signal_path.write_bytes(b"not a fifo")
+            try:
+                publish_http = should_publish_http(
+                    writer_pool,
+                    raw_data,
+                    shm_path=None,
+                    shm_only=False,
+                )
+                self.assertTrue(publish_http)
+                with self.assertRaises(ValueError):
+                    should_publish_http(
+                        writer_pool,
+                        raw_data,
+                        shm_path=None,
+                        shm_only=True,
+                    )
+                mirrored_path_string = str(mirrored_path)
+                publish_http = should_publish_http(
+                    writer_pool,
+                    raw_data,
+                    shm_path=mirrored_path_string,
+                    shm_only=False,
+                )
+                self.assertTrue(publish_http)
+                publish_http = should_publish_http(
+                    writer_pool,
+                    raw_data,
+                    shm_path=mirrored_path_string,
+                    shm_only=True,
+                )
+                self.assertFalse(publish_http)
+                invalid_path_string = str(invalid_path)
+                publish_http = should_publish_http(
+                    writer_pool,
+                    raw_data,
+                    shm_path=invalid_path_string,
+                    shm_only=True,
+                )
+                self.assertTrue(publish_http)
+            finally:
+                writer_pool.close()
+
+    async def test_subscriptions_reject_invalid_max_frequency(self) -> None:
+        """Reject invalid rate limits before opening a subscription."""
+
+        async def on_data(_raw_data: RawData) -> None:
+            return
+
+        invalid_frequencies = (0.0, -1.0, float("inf"), float("nan"))
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = str(Path(directory) / "invalid-frequency")
+            for max_frequency in invalid_frequencies:
+                with self.subTest(max_frequency=max_frequency):
+                    try:
+                        subscription = create_shm_subscription(
+                            on_data,
+                            channel_path,
+                            1,
+                            max_frequency=max_frequency,
+                        )
+                    except ValueError as error:
+                        self.assertRegex(
+                            str(error),
+                            "finite positive number",
+                        )
+                    else:
+                        await subscription.unsubscribe()
+                        self.fail("Invalid max_frequency was accepted.")
+
+        for context_class in (
+            ContextManagerCreateContext,
+            ContextManagerUseContext,
+        ):
+            context = object.__new__(context_class)
+            with self.subTest(context_class=context_class.__name__):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "finite positive number",
+                ):
+                    await context.subscribe(on_data, max_frequency=0.0)
+
+    async def test_enqueue_retries_when_queue_refills(self) -> None:
+        """Keep the newest payload when insertion encounters another full queue."""
+        subscription = object.__new__(_ShmSubscription)
+        subscription._closed = False
+        subscription._when = Mock()
+        subscription._when.now.return_value = True
+        queue: asyncio.Queue[RawData] = asyncio.Queue(maxsize=1)
+        stale_payload = RawData(content=b"stale", content_type=MIME_TEXT)
+        competing_payload = RawData(
+            content=b"competing", content_type=MIME_TEXT
+        )
+        expected_payload = RawData(content=b"expected", content_type=MIME_TEXT)
+        queue.put_nowait(stale_payload)
+
+        original_put_nowait = queue.put_nowait
+        put_attempts = 0
+
+        def put_nowait(item: RawData) -> None:
+            nonlocal put_attempts
+            put_attempts += 1
+            if put_attempts == 2:
+                original_put_nowait(competing_payload)
+            original_put_nowait(item)
+
+        queue.put_nowait = put_nowait  # type: ignore[method-assign]
+        subscription._queue = queue
+
+        subscription._enqueue(expected_payload)
+
+        queued_payload = queue.get_nowait()
+        self.assertEqual(queued_payload, expected_payload)
+        self.assertEqual(put_attempts, 3)
+        queue.task_done()
+        await asyncio.wait_for(queue.join(), timeout=1)
+
+    async def test_enqueue_respects_max_frequency(self) -> None:
+        """Discard SHM payloads that arrive before the next local interval."""
+        subscription = object.__new__(_ShmSubscription)
+        subscription._closed = False
+        subscription._when = Mock()
+        subscription._when.now.side_effect = [True, False, True]
+        queue: asyncio.Queue[RawData] = asyncio.Queue(maxsize=3)
+        first_payload = RawData(content=b"first", content_type=MIME_TEXT)
+        skipped_payload = RawData(
+            content=b"skipped",
+            content_type=MIME_TEXT,
+        )
+        latest_payload = RawData(content=b"latest", content_type=MIME_TEXT)
+        subscription._queue = queue
+
+        subscription._enqueue(first_payload)
+        subscription._enqueue(skipped_payload)
+        subscription._enqueue(latest_payload)
+
+        self.assertEqual(queue.get_nowait(), first_payload)
+        queue.task_done()
+        self.assertEqual(queue.get_nowait(), latest_payload)
+        queue.task_done()
+        await asyncio.wait_for(queue.join(), timeout=1)
+
+    async def test_processor_marks_queue_item_done(self) -> None:
+        """Keep queue joins usable after a callback completes."""
+        subscription = object.__new__(_ShmSubscription)
+        queue: asyncio.Queue[RawData] = asyncio.Queue()
+        raw_data = RawData(content=b"payload", content_type=MIME_TEXT)
+        on_data = AsyncMock()
+        subscription._queue = queue
+        subscription._on_data = on_data
+        processor_task = asyncio.create_task(subscription._process())
+        try:
+            queue.put_nowait(raw_data)
+            await asyncio.wait_for(queue.join(), timeout=1)
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        on_data.assert_awaited_once_with(raw_data)
+
+    async def test_unsubscribe_cancels_processor_after_reader_stop_failure(
+        self,
+    ) -> None:
+        """Do not orphan a callback worker when reader shutdown fails."""
+        processor_started = asyncio.Event()
+        processor_cancelled = asyncio.Event()
+        reader = Mock()
+        reader.stop.side_effect = RuntimeError("reader stop failed")
+        unsubscribe_callback = Mock()
+        subscription = object.__new__(_ShmSubscription)
+        subscription._closed = False
+        subscription._reader = reader
+        subscription._on_unsubscribe = unsubscribe_callback
+
+        async def process() -> None:
+            processor_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                processor_cancelled.set()
+                raise
+
+        processor_task = asyncio.create_task(process())
+        subscription._processor_task = processor_task
+        try:
+            await processor_started.wait()
+            with self.assertRaisesRegex(RuntimeError, "reader stop failed"):
+                await subscription.unsubscribe()
+        finally:
+            processor_task.cancel()
+            await asyncio.gather(processor_task, return_exceptions=True)
+
+        self.assertTrue(processor_cancelled.is_set())
+        unsubscribe_callback.assert_called_once_with(subscription)
+
+    async def test_callback_can_unsubscribe_its_own_shm_subscription(
+        self,
+    ) -> None:
+        """Finish the active callback without cancelling its own task."""
+        callback_finished = asyncio.Event()
+        reader = Mock()
+        subscription = object.__new__(_ShmSubscription)
+        subscription._closed = False
+        subscription._reader = reader
+        subscription._on_unsubscribe = Mock()
+        subscription._queue = asyncio.Queue()
+
+        async def on_data(_raw_data: RawData) -> None:
+            await subscription.unsubscribe()
+            callback_finished.set()
+
+        subscription._on_data = on_data
+        processor_task = asyncio.create_task(subscription._process())
+        subscription._processor_task = processor_task
+        subscription._queue.put_nowait(
+            RawData(content=b"payload", content_type=MIME_TEXT),
+        )
+
+        await asyncio.wait_for(callback_finished.wait(), timeout=1)
+        await asyncio.wait_for(subscription._queue.join(), timeout=1)
+        await asyncio.wait_for(processor_task, timeout=1)
+
+        reader.stop.assert_called_once()
+        subscription._on_unsubscribe.assert_called_once_with(subscription)
+        self.assertFalse(processor_task.cancelled())
+
+    async def test_reader_start_failure_does_not_create_processor_task(
+        self,
+    ) -> None:
+        """Avoid leaving a cancelled processor task when reader startup fails."""
+        reader = Mock()
+        reader.start.side_effect = RuntimeError("reader startup failed")
+        loop = Mock()
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with patch(
+            "dtps.shm.asyncio.get_running_loop",
+            return_value=loop,
+        ), patch(
+            "dtps.shm.ShmReader",
+            return_value=reader,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "reader startup failed",
+        ):
+            _ShmSubscription(on_data, "channel", queue_size=1)
+
+        loop.create_task.assert_not_called()
+
+    async def test_processor_start_failure_stops_reader(self) -> None:
+        """Release reader resources when processor task creation fails."""
+        reader = Mock()
+        processor = Mock()
+        process = Mock(return_value=processor)
+        loop = Mock()
+        loop.create_task.side_effect = RuntimeError("processor startup failed")
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with patch(
+            "dtps.shm.asyncio.get_running_loop",
+            return_value=loop,
+        ), patch(
+            "dtps.shm.ShmReader",
+            return_value=reader,
+        ), patch.object(
+            _ShmSubscription,
+            "_process",
+            new=process,
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "processor startup failed",
+        ):
+            _ShmSubscription(on_data, "channel", queue_size=1)
+
+        reader.start.assert_called_once()
+        reader.stop.assert_called_once()
+        processor.close.assert_called_once()
+
+    def test_frequency_ignores_only_stale_publications(self) -> None:
+        """Avoid indexing an emptied publication history after a clock jump."""
+        context = object.__new__(ContextManagerUseContext)
+        context.last_published = [0.0]
+
+        with patch("dtps.ergo_use.time.time", return_value=20.0):
+            frequency = context._get_frequency_publishing()
+
+        self.assertEqual(frequency, 0.0)
+        self.assertEqual(context.last_published, [])
+
+    @test_timeout(5)
+    async def test_context_publish_mirrors_http_and_shm(self) -> None:
+        """Mirror one RawData value to both selected transport paths."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "mirrored"
+            shm_path = str(channel_path)
+            async with create_use_pair("shmmirror") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                expected = RawData(
+                    content=b"mirrored payload",
+                    content_type=MIME_TEXT,
+                )
+                http_received: list[RawData] = []
+                shm_received: list[RawData] = []
+                dtps_event = asyncio.Event()
+                shm_event = asyncio.Event()
+
+                async def on_http(raw_data: RawData) -> None:
+                    http_received.append(raw_data)
+                    dtps_event.set()
+
+                async def on_shm(raw_data: RawData) -> None:
+                    shm_received.append(raw_data)
+                    shm_event.set()
+
+                http_subscription = await use_topic.subscribe(on_http)
+                shm_subscription = await use_topic.subscribe(
+                    on_shm,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                try:
+                    await create_topic.publish(expected, shm_path=shm_path)
+                    await asyncio.wait_for(dtps_event.wait(), timeout=1)
+                    await asyncio.wait_for(shm_event.wait(), timeout=1)
+                finally:
+                    await shm_subscription.unsubscribe()
+                    await http_subscription.unsubscribe()
+
+        self.assertEqual(http_received, [expected])
+        self.assertEqual(shm_received, [expected])
+
+    @test_timeout(5)
+    async def test_publisher_can_use_shm_only(self) -> None:
+        """Deliver a RawData value through a remote SHM-only publisher."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "publisher-only"
+            shm_path = str(channel_path)
+            async with create_use_pair("shmpublisher") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                expected = RawData(
+                    content=b"shared-memory only",
+                    content_type=MIME_TEXT,
+                )
+                received: list[RawData] = []
+                received_event = asyncio.Event()
+
+                async def on_data(raw_data: RawData) -> None:
+                    received.append(raw_data)
+                    received_event.set()
+
+                subscription = await create_topic.subscribe(
+                    on_data,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                publisher = await use_topic.publisher()
+                try:
+                    await publisher.publish(
+                        expected,
+                        shm_path=shm_path,
+                        shm_only=True,
+                    )
+                    await asyncio.wait_for(received_event.wait(), timeout=1)
+                finally:
+                    await publisher.terminate()
+                    await subscription.unsubscribe()
+
+        self.assertEqual(received, [expected])
+
+    @test_timeout(5)
+    async def test_remote_context_publish_can_use_shm_only(self) -> None:
+        """Deliver a RawData value through direct remote context publishing."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "remote-context-only"
+            shm_path = str(channel_path)
+            async with create_use_pair("shmremotecontext") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                expected = RawData(
+                    content=b"direct shared-memory only",
+                    content_type=MIME_TEXT,
+                )
+                received: list[RawData] = []
+                received_event = asyncio.Event()
+
+                async def on_data(raw_data: RawData) -> None:
+                    received.append(raw_data)
+                    received_event.set()
+
+                subscription = await create_topic.subscribe(
+                    on_data,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                try:
+                    await use_topic.publish(
+                        expected,
+                        shm_path=shm_path,
+                        shm_only=True,
+                    )
+                    await asyncio.wait_for(received_event.wait(), timeout=1)
+                finally:
+                    await subscription.unsubscribe()
+
+        self.assertEqual(received, [expected])
+
+    @test_timeout(5)
+    async def test_mirrored_subscription_does_not_duplicate_callbacks(
+        self,
+    ) -> None:
+        """A non-SHM-only subscriber keeps its single HTTP delivery path."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "non-duplicated"
+            shm_path = str(channel_path)
+            async with create_use_pair("shmduplicate") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                expected = RawData(
+                    content=b"one callback",
+                    content_type=MIME_TEXT,
+                )
+                received: list[RawData] = []
+                received_event = asyncio.Event()
+                unexpected_callback_event = asyncio.Event()
+
+                async def on_data(raw_data: RawData) -> None:
+                    received.append(raw_data)
+                    if len(received) == 1:
+                        received_event.set()
+                    else:
+                        unexpected_callback_event.set()
+
+                subscription = await use_topic.subscribe(
+                    on_data,
+                    shm_path=shm_path,
+                )
+                try:
+                    await create_topic.publish(expected, shm_path=shm_path)
+                    await asyncio.wait_for(received_event.wait(), timeout=1)
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await asyncio.wait_for(
+                            unexpected_callback_event.wait(),
+                            timeout=0.1,
+                        )
+                finally:
+                    await subscription.unsubscribe()
+
+        self.assertEqual(received, [expected])
+
+    @test_timeout(5)
+    async def test_unsubscribe_stops_shm_delivery(self) -> None:
+        """Stopping a SHM subscription stops its reader and processor."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "unsubscribe"
+            shm_path = str(channel_path)
+            async with create_use_pair("shmunsubscribe") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                first_value = RawData(
+                    content=b"first",
+                    content_type=MIME_TEXT,
+                )
+                second_value = RawData(
+                    content=b"second",
+                    content_type=MIME_TEXT,
+                )
+                received: list[RawData] = []
+                received_event = asyncio.Event()
+                unexpected_callback_event = asyncio.Event()
+
+                async def on_data(raw_data: RawData) -> None:
+                    received.append(raw_data)
+                    if len(received) == 1:
+                        received_event.set()
+                    else:
+                        unexpected_callback_event.set()
+
+                subscription = await use_topic.subscribe(
+                    on_data,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                await create_topic.publish(
+                    first_value,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                await asyncio.wait_for(received_event.wait(), timeout=1)
+                await subscription.unsubscribe()
+                await create_topic.publish(
+                    second_value,
+                    shm_path=shm_path,
+                    shm_only=True,
+                )
+                with self.assertRaises(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        unexpected_callback_event.wait(),
+                        timeout=0.1,
+                    )
+
+        self.assertEqual(received, [first_value])
+
+    @test_timeout(5)
+    async def test_shm_only_requires_a_path(self) -> None:
+        """Reject a transport request that cannot identify an SHM channel."""
+        async with create_use_pair("shmrequirespath") as (
+            context_create,
+            _context_use,
+        ):
+            create_topic_context = context_create / "topic"
+            create_topic = await create_topic_context.queue_create()
+            payload = RawData(
+                content=b"missing path",
+                content_type=MIME_TEXT,
+            )
+
+            with self.assertRaises(ValueError):
+                await create_topic.publish(payload, shm_only=True)
+
+    @test_timeout(5)
+    async def test_shm_only_subscription_requires_a_path(self) -> None:
+        """Reject an SHM-only subscription without a channel path."""
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "missing.sock"
+            async with create_use(
+                name="shmsubscriberequirespath",
+                socket_node=str(socket_path),
+            ) as context_use:
+                direct_config = ContextConfig(patient=False)
+                direct_context = context_use.configure(
+                    direct_config,
+                )
+                direct_topic = direct_context / "topic"
+                with self.assertRaises(ValueError):
+                    await direct_topic.subscribe(
+                        on_data,
+                        shm_only=True,
+                    )
+
+    @test_timeout(5)
+    async def test_shm_only_subscription_does_not_require_http_availability(
+        self,
+    ) -> None:
+        """Create a local SHM subscription while its HTTP endpoint is absent."""
+
+        async def on_data(_raw_data: RawData) -> None:
+            pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "missing.sock"
+            shm_path = Path(directory) / "subscription"
+            async with create_use(
+                name="shmsubscribeunreachable",
+                socket_node=str(socket_path),
+            ) as context_use:
+                direct_config = ContextConfig(patient=False)
+                direct_context = context_use.configure(
+                    direct_config,
+                )
+                direct_topic = direct_context / "topic"
+                subscription = await direct_topic.subscribe(
+                    on_data,
+                    shm_path=str(shm_path),
+                    shm_only=True,
+                )
+                try:
+                    socket_exists = socket_path.exists()
+                    self.assertFalse(socket_exists)
+                finally:
+                    await subscription.unsubscribe()
+
+    @test_timeout(5)
+    async def test_failed_shm_only_publish_falls_back_to_http(self) -> None:
+        """Preserve HTTP delivery when the configured SHM channel is invalid."""
+        with tempfile.TemporaryDirectory() as directory:
+            channel_path = Path(directory) / "invalid"
+            shm_path = str(channel_path)
+            signal_path = Path(shm_path + ".p2c")
+            signal_path.write_bytes(b"not a fifo")
+            async with create_use_pair("shmfallback") as (
+                context_create,
+                context_use,
+            ):
+                create_topic_context = context_create / "topic"
+                create_topic = await create_topic_context.queue_create()
+                use_topic = context_use / "topic"
+                expected = RawData(
+                    content=b"fallback payload",
+                    content_type=MIME_TEXT,
+                )
+                received: list[RawData] = []
+                received_event = asyncio.Event()
+
+                async def on_data(raw_data: RawData) -> None:
+                    received.append(raw_data)
+                    received_event.set()
+
+                subscription = await use_topic.subscribe(on_data)
+                try:
+                    await create_topic.publish(
+                        expected,
+                        shm_path=shm_path,
+                        shm_only=True,
+                    )
+                    await asyncio.wait_for(received_event.wait(), timeout=1)
+                finally:
+                    await subscription.unsubscribe()
+
+        self.assertEqual(received, [expected])


### PR DESCRIPTION
This pull request adds support for shared-memory (SHM) subscriptions and publishing to the DTPS framework, introduces robust resource management for subscriptions and background tasks, and updates the documentation accordingly. The main changes include new SHM integration options in the API, improved lifecycle management for subscriptions and tasks, and enhanced shutdown procedures to prevent resource leaks.

**Shared-memory (SHM) integration:**
* Added support for publishing and subscribing via SHM channels in `ContextManagerCreate`, `ContextManagerUse`, and related interfaces. This includes new arguments (`shm_path`, `shm_only`) to `publish` and `subscribe` methods, and logic to route messages through SHM or HTTP as appropriate. [[1]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceR52-R65) [[2]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceR333-R361) [[3]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceL291-R424) [[4]](diffhunk://#diff-6cf7966d6ae51d450c893e5566c6a270224865b21e918cca0f5ffbf8b9da2aa7R164-R174) [[5]](diffhunk://#diff-6cf7966d6ae51d450c893e5566c6a270224865b21e918cca0f5ffbf8b9da2aa7L192-R206) [[6]](diffhunk://#diff-6cf7966d6ae51d450c893e5566c6a270224865b21e918cca0f5ffbf8b9da2aa7L346-R364)
* Integrated SHM utility functions and writer pool management from the new `.shm` module. [[1]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceR52-R65) [[2]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R68-R74)

**Subscription and resource management:**
* Implemented tracking and cleanup of active subscriptions in both create and use contexts, ensuring all are properly unsubscribed during shutdown. Added methods like `remember_subscription`, `forget_subscription`, and `_unsubscribe_all`/`_unsubscribe_subscriptions`. [[1]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceR77-R79) [[2]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceR98-R148) [[3]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R115-R273)
* For `ContextManagerUse`, added thread-safe management of background tasks and SHM subscriptions, with robust cancellation and error logging during shutdown. [[1]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R115-R273) [[2]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R346-R357)

**API and interface changes:**
* Updated the `PublisherInterface` and related abstract methods to accept SHM parameters and clarified their docstrings with the new behavior. [[1]](diffhunk://#diff-6cf7966d6ae51d450c893e5566c6a270224865b21e918cca0f5ffbf8b9da2aa7L192-R206) [[2]](diffhunk://#diff-6cf7966d6ae51d450c893e5566c6a270224865b21e918cca0f5ffbf8b9da2aa7L346-R364)

**Documentation:**
* Updated the documentation table of contents to include the new `impl/shm` section, reflecting the addition of SHM support.

**Type and import updates:**
* Added necessary imports and type annotations to support new SHM and resource management features, including use of `Set`, `Lock`, and the `.shm` module. [[1]](diffhunk://#diff-0d1b0f2076f32be86a6bba3dbe8bd530beb1091910680fca408b9a57137ba4ceL4-R4) [[2]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R7) [[3]](diffhunk://#diff-55925f40be4b867c7ccc32fa5a905c17b58e7e2c4e11b389b20b914a70ce5b17R21)

These changes collectively improve the system's flexibility, performance, and reliability, especially for high-frequency or low-latency use cases leveraging shared-memory transport.